### PR TITLE
bipartite (gw)dsp terms

### DIFF
--- a/R/formula.utils.R
+++ b/R/formula.utils.R
@@ -200,7 +200,7 @@ fix.curved.ergm <- function(object,...){
 fix.curved.formula <- function(object, theta, response=NULL, ...){
   recipes<-list()
   is.fixed.1<-function(a) is.null(a$fixed) || a$fixed==FALSE
-  recipes$dgwdsp<-recipes$dgwesp<-recipes$dgwnsp<-recipes$gwdsp<-recipes$gwesp<-recipes$gwnsp<-
+  recipes$dgwdsp<-recipes$dgwesp<-recipes$dgwnsp<-recipes$gwdsp<-recipes$gwesp<-recipes$gwnsp<-recipes$gwb1dsp<-recipes$gwb2dsp<-
     list(filter=is.fixed.1, tocoef=1, toarg=list(decay=2), constant=list(fixed=TRUE))
   recipes$altkstar<-
     list(filter=is.fixed.1, tocoef=1, toarg=list(lambda=2), constant=list(fixed=TRUE))
@@ -278,7 +278,7 @@ enformulate.curved.ergm <- function(object,...){
 enformulate.curved.formula <- function(object, theta, response=NULL, ...){
   recipes<-list()
   is.fixed.1<-function(a) is.null(a$fixed) || a$fixed==FALSE
-  recipes$dgwdsp<-recipes$dgwesp<-recipes$dgwnsp<-recipes$gwdsp<-recipes$gwesp<-recipes$gwnsp<-
+  recipes$dgwdsp<-recipes$dgwesp<-recipes$dgwnsp<-recipes$gwdsp<-recipes$gwesp<-recipes$gwnsp<-recipes$gwb1dsp<-recipes$gwb2dsp<-
     list(filter=is.fixed.1, tocoef=1, toarg=list(decay=2))
   recipes$altkstar<-
     list(filter=is.fixed.1, tocoef=1, toarg=list(lambda=2))

--- a/man/ergm-terms.Rd
+++ b/man/ergm-terms.Rd
@@ -75,10 +75,10 @@
 \alias{equalto}
 \alias{greaterthan}
 \alias{gwb1degree}
-\alias{gwb2degree}
-\alias{gwdegree}
 \alias{gwb1dsp}
+\alias{gwb2degree}
 \alias{gwb2dsp}
+\alias{gwdegree}
 \alias{gwdsp}
 \alias{gwesp}
 \alias{gwidegree}
@@ -462,8 +462,11 @@
       \Bipartite}
 
     \item{\code{b1dsp(d)}  (binary)  (bipartite) (undirected)}{\emph{Dyadwise shared partners for dyads in the first bipartition:}
-      This term can only be used with bipartite networks.  It functions like the \code{dsp} term, but only considers dyads in the first bipartition when
-      counting shared partners.  (Those shared partners, of course, must be members of the second bipartition.)}
+      The \code{d} argument is a vector of distinct integers. This term adds one
+      network statistic to the model for each element in \code{d}; the \eqn{i}th
+      such statistic equals the number of dyads in the first bipartition with exactly
+      \code{d[i]} shared partners.  (Those shared partners, of course, must be members 
+      of the second bipartition.)  This term can only be used with bipartite networks.}
 
     \item{\code{b1factor(attr, base=1, levels=-1)}  (binary)  (bipartite) (undirected)  (dyad-independent) (frequently-used) (categorical nodal attribute),
       \code{b1factor(attr, base=1, levels=-1, form="sum")}  (valued)  (bipartite)  (undirected)  (dyad-independent) (frequently-used) (categorical nodal attribute)
@@ -670,8 +673,11 @@
       \Bipartite}
 
     \item{\code{b2dsp(d)}  (binary)  (bipartite) (undirected)}{\emph{Dyadwise shared partners for dyads in the second bipartition:}
-      This term can only be used with bipartite networks.  It functions like the \code{dsp} term, but only considers dyads in the second bipartition when
-      counting shared partners.  (Those shared partners, of course, must be members of the first bipartition.)}
+      The \code{d} argument is a vector of distinct integers. This term adds one
+      network statistic to the model for each element in \code{d}; the \eqn{i}th
+      such statistic equals the number of dyads in the second bipartition with exactly
+      \code{d[i]} shared partners.  (Those shared partners, of course, must be members 
+      of the first bipartition.)  This term can only be used with bipartite networks.}
 
     \item{\code{b2factor(attr, base=1, levels=-1)}  (binary)  (bipartite) (undirected)  (dyad-independent) (categorical nodal attribute) (frequently-used),
       \code{b2factor(attr, base=1, levels=-1, form="sum")}  (valued)  (bipartite)  (undirected)  (dyad-independent) (categorical nodal attribute) (frequently-used)
@@ -1112,6 +1118,19 @@
       This term can only be used with undirected bipartite
       networks.}
 
+    \item{\code{gwb1dsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (bipartite) (undirected) (curved)}{\emph{Geometrically weighted
+	dyadwise shared partner distribution for dyads in the first bipartition:}
+      This term adds one network statistic to the model equal to the geometrically
+      weighted dyadwise shared partner distribution for dyads in the first bipartition,
+      with decay parameter \code{decay} parameter, which should be non-negative. The value supplied for
+      this parameter may be fixed (if \code{fixed=TRUE}),
+      or it may be used instead as the starting value for the estimation of \code{decay}
+      in a curved exponential family model (when \code{fixed=FALSE}, the default) (see Hunter and Handcock, 2006).
+      This term can only be used with bipartite networks.
+
+      \GWCutoff{b1dsp}}
+      
+      
     \item{\code{gwb2degree(decay, fixed=FALSE, attr=NULL, cutoff=30, levels=NULL)}  (binary)  (bipartite)  (undirected) (curved)}{\emph{Geometrically weighted
 	degree distribution for the second mode in a bipartite (aka two-mode)
 	network:}
@@ -1135,6 +1154,20 @@
       This term can only be used with undirected bipartite
       networks.}
 
+
+    \item{\code{gwb2dsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (bipartite) (undirected) (curved)}{\emph{Geometrically weighted
+	dyadwise shared partner distribution for dyads in the second bipartition:}
+      This term adds one network statistic to the model equal to the geometrically
+      weighted dyadwise shared partner distribution for dyads in the second bipartition,
+      with decay parameter \code{decay} parameter, which should be non-negative. The value supplied for
+      this parameter may be fixed (if \code{fixed=TRUE}),
+      or it may be used instead as the starting value for the estimation of \code{decay}
+      in a curved exponential family model (when \code{fixed=FALSE}, the default) (see Hunter and Handcock, 2006).
+      This term can only be used with bipartite networks.
+
+      \GWCutoff{b2dsp}}
+      
+      
     \item{\code{gwdegree(decay, fixed=FALSE, attr=NULL, cutoff=30, levels=NULL)}  (binary)  (undirected)  (curved) (frequently-used)
     }{\emph{Geometrically weighted
 	degree distribution:}
@@ -1153,17 +1186,6 @@
       statistics are calculated for nodes having each separate
       value of the attribute.  This term can only be used with undirected networks.}
 
-    \item{\code{gwb1dsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (bipartite) (undirected) (curved)}{\emph{Geometrically weighted
-	dyadwise shared partner distribution for dyads in the first bipartition:}
-      This term can only be used with bipartite networks.  It functions like the \code{gwdsp} term, but only considers dyads in the first bipartition when
-      counting shared partners.  (Those shared partners, of course, must be members of the second bipartition.)
-    }
-
-    \item{\code{gwb2dsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (bipartite) (undirected) (curved)}{\emph{Geometrically weighted
-	dyadwise shared partner distribution for dyads in the second bipartition:}
-      This term can only be used with bipartite networks.  It functions like the \code{gwdsp} term, but only considers dyads in the second bipartition when
-      counting shared partners.  (Those shared partners, of course, must be members of the first bipartition.)
-    }
 
     \item{\code{gwdsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (directed)  (undirected)  (curved)}{\emph{Geometrically weighted
 	dyadwise shared partner distribution:}

--- a/man/ergm-terms.Rd
+++ b/man/ergm-terms.Rd
@@ -24,6 +24,7 @@
 \alias{b1cov}
 \alias{b1degrange}
 \alias{b1degree}
+\alias{b1dsp}
 \alias{b1factor}
 \alias{b1mindegree}
 \alias{b1nodematch}
@@ -35,6 +36,7 @@
 \alias{b2cov}
 \alias{b2degrange}
 \alias{b2degree}
+\alias{b2dsp}
 \alias{b2factor}
 \alias{b2mindegree}
 \alias{b2nodematch}
@@ -75,6 +77,8 @@
 \alias{gwb1degree}
 \alias{gwb2degree}
 \alias{gwdegree}
+\alias{gwb1dsp}
+\alias{gwb2dsp}
 \alias{gwdsp}
 \alias{gwesp}
 \alias{gwidegree}
@@ -457,6 +461,10 @@
 
       \Bipartite}
 
+    \item{\code{b1dsp(d)}  (binary)  (bipartite) (undirected)}{\emph{Dyadwise shared partners for dyads in the first bipartition:}
+      This term can only be used with bipartite networks.  It functions like the \code{dsp} term, but only considers dyads in the first bipartition when
+      counting shared partners.  (Those shared partners, of course, must be members of the second bipartition.)}
+
     \item{\code{b1factor(attr, base=1, levels=-1)}  (binary)  (bipartite) (undirected)  (dyad-independent) (frequently-used) (categorical nodal attribute),
       \code{b1factor(attr, base=1, levels=-1, form="sum")}  (valued)  (bipartite)  (undirected)  (dyad-independent) (frequently-used) (categorical nodal attribute)
     }{\emph{Factor attribute effect for
@@ -660,6 +668,10 @@
       value of the \code{by} attribute.
 
       \Bipartite}
+
+    \item{\code{b2dsp(d)}  (binary)  (bipartite) (undirected)}{\emph{Dyadwise shared partners for dyads in the second bipartition:}
+      This term can only be used with bipartite networks.  It functions like the \code{dsp} term, but only considers dyads in the second bipartition when
+      counting shared partners.  (Those shared partners, of course, must be members of the first bipartition.)}
 
     \item{\code{b2factor(attr, base=1, levels=-1)}  (binary)  (bipartite) (undirected)  (dyad-independent) (categorical nodal attribute) (frequently-used),
       \code{b2factor(attr, base=1, levels=-1, form="sum")}  (valued)  (bipartite)  (undirected)  (dyad-independent) (categorical nodal attribute) (frequently-used)
@@ -1140,6 +1152,18 @@
 	Attributes and Levels} for details) then separate degree
       statistics are calculated for nodes having each separate
       value of the attribute.  This term can only be used with undirected networks.}
+
+    \item{\code{gwb1dsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (bipartite) (undirected) (curved)}{\emph{Geometrically weighted
+	dyadwise shared partner distribution for dyads in the first bipartition:}
+      This term can only be used with bipartite networks.  It functions like the \code{gwdsp} term, but only considers dyads in the first bipartition when
+      counting shared partners.  (Those shared partners, of course, must be members of the second bipartition.)
+    }
+
+    \item{\code{gwb2dsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (bipartite) (undirected) (curved)}{\emph{Geometrically weighted
+	dyadwise shared partner distribution for dyads in the second bipartition:}
+      This term can only be used with bipartite networks.  It functions like the \code{gwdsp} term, but only considers dyads in the second bipartition when
+      counting shared partners.  (Those shared partners, of course, must be members of the first bipartition.)
+    }
 
     \item{\code{gwdsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (directed)  (undirected)  (curved)}{\emph{Geometrically weighted
 	dyadwise shared partner distribution:}

--- a/src/changestats_dgw_sp.c
+++ b/src/changestats_dgw_sp.c
@@ -1277,3 +1277,26 @@ D_CHANGESTAT_FN(d_dgwnsp) {
 
 
 
+/*****************
+ changestat: d_ddspbwrap
+*****************/
+
+D_CHANGESTAT_FN(d_ddspbwrap) {
+  d_ddsp(ntoggles, tails, heads, mtp, nwp);
+  
+  // correct for double counting of directed vs. undirected dyads
+  for(int ind = 0; ind < N_CHANGE_STATS; ind++) CHANGE_STAT[ind] /= 2.0;
+}
+
+
+/*****************
+ changestat: d_dgwdspbwrap
+*****************/
+
+D_CHANGESTAT_FN(d_dgwdspbwrap) {
+  d_dgwdsp(ntoggles, tails, heads, mtp, nwp);
+  
+  // correct for double counting of directed vs. undirected dyads
+  CHANGE_STAT[0] /= 2.0;
+}
+

--- a/src/changestats_dgw_sp.h
+++ b/src/changestats_dgw_sp.h
@@ -49,4 +49,8 @@ D_CHANGESTAT_FN(d_dgwdsp);
 D_CHANGESTAT_FN(d_dnsp);
 D_CHANGESTAT_FN(d_dgwnsp);
 
+/*Changescore functions*/
+D_CHANGESTAT_FN(d_ddspbwrap);
+D_CHANGESTAT_FN(d_dgwdspbwrap);
+
 #endif

--- a/tests/termTests.bipartite.R
+++ b/tests/termTests.bipartite.R
@@ -87,13 +87,13 @@ if (!all(s.d==c(42,12)) ||
 	print("Passed b1degree term test")
 }
 
-
 #b1degree, bipartite, undirected
 num.tests=num.tests+1
 s.d <- summary(bipnw~b1degree(1:3))
 e.d <- ergm(bipnw~b1degree(1:3), estimate="MPLE")
 s.db <- summary(bipnw~b1degree(2:4, by="Letter"))
 e.db <- ergm(bipnw~b1degree(2, by=~Letter), estimate="MPLE")
+
 if (!all(s.d==c(30,8,2)) ||
     !all(round(e.d$coef+c(2.991, 5.442, 6.484),3)==0) ||
     !all(s.db==c(2,1,1,3,1,1,3,0,0)) ||
@@ -103,6 +103,25 @@ if (!all(s.d==c(30,8,2)) ||
 } else {
   num.passed.tests=num.passed.tests+1
   print("Passed b1degree term test")
+}
+
+#b1dsp, bipartite
+num.tests=num.tests+1
+s.d0 <- summary(bipnw~b1dsp(0))
+e.d0 <- ergm(bipnw~b1dsp(0), estimate="MPLE")
+s.d1 <- summary(bipnw~b1dsp(1:3))
+e.d1 <- ergm(bipnw~b1dsp(1:3), estimate="MPLE")
+
+if (s.d0 != 4900 ||
+    !all(s.d1 == c(49,1,0)) ||
+    round(e.d0$coef - 2.11343,3) !=0 ||    
+    !all(round(e.d1$coef[1:2] + c(2.096629, 3.0399271),3)==0) ||
+    !is.infinite(e.d1$coef[3])) {
+ print(list(s.d0=s.d0, e.d0=e.d0, s.d1=s.d1, e.d1=e.d1))
+ stop("Failed b1dsp term test")
+} else {
+  num.passed.tests=num.passed.tests+1
+  print("Passed b1dsp term test")
 }
 
 
@@ -299,6 +318,26 @@ if (!all(s.d==c(6,9,8)) ||
 }
 
 
+#b2dsp, bipartite
+num.tests=num.tests+1
+s.d0 <- summary(bipnw~b2dsp(0))
+e.d0 <- ergm(bipnw~b2dsp(0), estimate="MPLE")
+s.d1 <- summary(bipnw~b2dsp(1:3))
+e.d1 <- ergm(bipnw~b2dsp(1:3), estimate="MPLE")
+
+if (s.d0 != 381 ||
+    !all(s.d1 == c(24,1,0)) ||
+    round(e.d0$coef - 2.829767 ,3) !=0 ||    
+    !all(round(e.d1$coef[1:2] + c(2.804156, 5.140782),3)==0) ||
+    !is.infinite(e.d1$coef[3])) {
+ print(list(s.d0=s.d0, e.d0=e.d0, s.d1=s.d1, e.d1=e.d1))
+ stop("Failed b2dsp term test")
+} else {
+  num.passed.tests=num.passed.tests+1
+  print("Passed b2dsp term test")
+}
+
+
 #b2mindegree, bipartite, undirected
 num.tests=num.tests+1
 s.d <- summary(bipnw~b2mindegree(1:3))
@@ -456,6 +495,28 @@ if (round(e.d$coef + 6.979, 3) != 0 ||
   print("Passed gwb1degree term test")
 }
 
+# gwb1dsp, bipartite
+num.tests=num.tests+1
+s.d0 <- summary(bipnw~gwb1dsp)
+s.d1 <- summary(bipnw~gwb1dsp(.3))
+s.d2 <- summary(bipnw~gwb1dsp(.3, TRUE))
+e.d2 <- ergm(bipnw~gwb1dsp(.3, TRUE), estimate="MPLE")
+s.d3 <- summary(bipnw~gwb1dsp(.3, TRUE, 1))
+e.d3 <- ergm(bipnw~gwb1dsp(.3, TRUE, 1), estimate="MPLE")
+
+if (!all(s.d0 == c(49,1,rep(0,27))) ||
+    !all(s.d1 == c(49,1,rep(0,27))) ||
+    round(s.d2 - 50.25918, 3) != 0 || 
+    round(s.d3 - 49, 3) != 0 || 
+    round(e.d2$coef + 2.105815, 3) != 0 ||
+    round(e.d3$coef + 2.072566, 3) != 0) {
+ print(list(s.d0=s.d0, s.d1=s.d1, s.d2=s.d2, e.d2=e.d2, s.d3=s.d3, e.d3=e.d3))
+ stop("Failed gwb1dsp term test")
+} else {
+  num.passed.tests=num.passed.tests+1
+  print("Passed gwb1dsp term test")
+}
+
 
 # gwb2degree, bipartite
 num.tests=num.tests+1
@@ -480,6 +541,27 @@ if (round(e.d$coef + 25.99385, 3) != 0 ||
   print("Passed gwb2degree term test")
 }
 
+# gwb2dsp, bipartite
+num.tests=num.tests+1
+s.d0 <- summary(bipnw~gwb2dsp)
+s.d1 <- summary(bipnw~gwb2dsp(.3))
+s.d2 <- summary(bipnw~gwb2dsp(.3, TRUE))
+e.d2 <- ergm(bipnw~gwb2dsp(.3, TRUE), estimate="MPLE")
+s.d3 <- summary(bipnw~gwb2dsp(.3, TRUE, 1))
+e.d3 <- ergm(bipnw~gwb2dsp(.3, TRUE, 1), estimate="MPLE")
+
+if (!all(s.d0 == c(24,1,rep(0,28))) ||
+    !all(s.d1 == c(24,1,rep(0,28))) ||
+    round(s.d2 - 25.25918, 3) != 0 || 
+    round(s.d3 - 24, 3) != 0 || 
+    round(e.d2$coef + 2.875923, 3) != 0 ||
+    round(e.d3$coef + 2.220758, 3) != 0) {
+ print(list(s.d0=s.d0, s.d1=s.d1, s.d2=s.d2, e.d2=e.d2, s.d3=s.d3, e.d3=e.d3))
+ stop("Failed gwb2dsp term test")
+} else {
+  num.passed.tests=num.passed.tests+1
+  print("Passed gwb2dsp term test")
+}
 
 
 if(num.passed.tests==num.tests)


### PR DESCRIPTION
closes statnet/ergm#94

changestats call directed dsp changestats with the appropriate type code (set in InitErgmTerm) and then divide by two (since directed dsp changestats appear to treat dyads as directed)

I don't know much about how curved terms work behind the scenes so give this a good look :)

