### PR TITLE
correct term balance

### DIFF
--- a/R/InitErgmTerm.R
+++ b/R/InitErgmTerm.R
@@ -1297,57 +1297,11 @@ InitErgmTerm.b2twostar <- function(nw, arglist, ..., version=packageVersion("erg
 }
 
 ################################################################################
-InitErgmTerm.balance<-function (nw, arglist, ..., version=packageVersion("ergm")) {
-  if(version <= as.package_version("3.9.4")){
-    a <- check.ErgmTerm(nw, arglist,
-                        varnames = c("attrname", "diff", "levels"),
-                        vartypes = c("character", "logical", "character,numeric,logical"),
-                        defaultvalues = list(NULL, FALSE, NULL),
-                        required = c(FALSE, FALSE, FALSE))
-    attrarg <- a$attrname
-    levels <- if(!is.null(a$levels)) I(a$levels) else NULL
-  }else{
-    a <- check.ErgmTerm(nw, arglist,
-                        varnames = c("attr", "diff", "levels"),
-                        vartypes = c(ERGM_VATTR_SPEC, "logical", ERGM_LEVELS_SPEC),
-                        defaultvalues = list(NULL, FALSE, NULL),
-                        required = c(FALSE, FALSE, FALSE))    
-    attrarg <- a$attr
-    levels <- a$levels    
-  }
+InitErgmTerm.balance<-function (nw, arglist, ...) {
+  a <- check.ErgmTerm(nw, arglist)
     
-  diff <- a$diff
-  if(!is.null(attrarg)){
-    nodecov <- ergm_get_vattr(attrarg, nw)
-    attrname <- attr(nodecov, "name")
-    u <- ergm_attr_levels(levels, nodecov, nw, levels = sort(unique(nodecov)))
-
-    if(any(is.na(nodecov))){u<-c(u,NA)}
-#
-#  Recode to numeric if necessary
-#
-   nodecov <- match(nodecov,u,nomatch=length(u)+1)
-   ui <- seq(along=u)
-
-   if (!diff) {
-     #     No parameters before covariates here, so no need for "ParamsBeforeCov"
-     coef.names <- paste("balance",attrname,sep=".")
-     inputs <- c(nodecov)
-   } else {
-     #  Number of input parameters before covariates equals number of
-     #  unique elements in nodecov, namely length(u)
-     coef.names <- paste("balance",attrname, u, sep=".")
-     inputs <- c(ui, nodecov)
-     attr(inputs, "ParamsBeforeCov") <- length(ui)
-   }
-  }else{
-    coef.names <- "balance"
-    inputs <- NULL
-  }
-  list(name="balance", coef.names=coef.names, inputs=inputs, dependence=TRUE, minval=0)
+  list(name="balance", coef.names="balance", dependence=TRUE, minval=0)
 }
-
-
 
 
 #=======================InitErgmTerm functions:  C============================#

--- a/man/ergm-terms.Rd
+++ b/man/ergm-terms.Rd
@@ -791,8 +791,8 @@
       triads in the network that are balanced. The balanced triads are those of
       type \code{102} or \code{300} in the categorization of Davis and Leinhardt (1972). For details on the 16 possible triad types, see
       \code{?triad.classify} in the \code{{sna}} package. For an undirected
-      network, the balanced triads are those with an even number of ties (i.e., 0
-      and 2).}
+      network, the balanced triads are those with an odd number of ties (i.e., 1
+      and 3).}
 
     \item{\code{coincidence(levels=NULL,active=0)}  (binary)  (bipartite)  (undirected)
     }{\emph{Coincident node count for the
@@ -1129,8 +1129,7 @@
       This term can only be used with bipartite networks.
 
       \GWCutoff{b1dsp}}
-      
-      
+
     \item{\code{gwb2degree(decay, fixed=FALSE, attr=NULL, cutoff=30, levels=NULL)}  (binary)  (bipartite)  (undirected) (curved)}{\emph{Geometrically weighted
 	degree distribution for the second mode in a bipartite (aka two-mode)
 	network:}
@@ -1154,7 +1153,6 @@
       This term can only be used with undirected bipartite
       networks.}
 
-
     \item{\code{gwb2dsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (bipartite) (undirected) (curved)}{\emph{Geometrically weighted
 	dyadwise shared partner distribution for dyads in the second bipartition:}
       This term adds one network statistic to the model equal to the geometrically
@@ -1166,8 +1164,7 @@
       This term can only be used with bipartite networks.
 
       \GWCutoff{b2dsp}}
-      
-      
+
     \item{\code{gwdegree(decay, fixed=FALSE, attr=NULL, cutoff=30, levels=NULL)}  (binary)  (undirected)  (curved) (frequently-used)
     }{\emph{Geometrically weighted
 	degree distribution:}
@@ -1185,7 +1182,6 @@
 	Attributes and Levels} for details) then separate degree
       statistics are calculated for nodes having each separate
       value of the attribute.  This term can only be used with undirected networks.}
-
 
     \item{\code{gwdsp(decay=0, fixed=FALSE, cutoff=30)}  (binary)  (directed)  (undirected)  (curved)}{\emph{Geometrically weighted
 	dyadwise shared partner distribution:}


### PR DESCRIPTION
closes statnet/ergm#67

arguments were not working so I removed them

also the doc was wrong; the term counts triads with 1 or 3 edges in the undirected case (not 0 or 2 as previously claimed)

as a test I implemented the balanced triad counting in R and it matched the current changestat behavior so the changestat itself is fine, it just didn't handle arguments or count what they doc said it did

incidentally the changestat could possibly be made to wrap triadcensus but there would be a need to collapse two statistics down to one (via summation); I think this can be done pretty easily within the changestat itself but I haven't seen it done elsewhere so I didn't bother changing it this time (but it would be a nice savings of ~ 250 lines of duplicated C code)