### PR TITLE
starmix

### DIFF
--- a/R/InitErgmTerm.R
+++ b/R/InitErgmTerm.R
@@ -690,17 +690,29 @@ InitErgmTerm.b1star <- function(nw, arglist, ..., version=packageVersion("ergm")
 }
 
 ################################################################################
-InitErgmTerm.b1starmix <- function(nw, arglist, ...) {
-  ### Check the network and arguments to make sure they are appropriate.
-  a <- check.ErgmTerm (nw, arglist, directed=FALSE, bipartite=TRUE,
-                       varnames = c("k", "attrname", "base", "diff", "levels"),
-                       vartypes = c("numeric", "character", "numeric", "logical", "character,numeric,logical"),
-                       defaultvalues = list(NULL, NULL, NULL, TRUE, NULL),
-                       required = c(TRUE, TRUE, FALSE, FALSE, FALSE))
+InitErgmTerm.b1starmix <- function(nw, arglist, ..., version=packageVersion("ergm")) {
+  if(version <= as.package_version("3.9.4")){
+    ### Check the network and arguments to make sure they are appropriate.
+    a <- check.ErgmTerm (nw, arglist, directed=FALSE, bipartite=TRUE,
+                         varnames = c("k", "attrname", "base", "diff"),
+                         vartypes = c("numeric", "character", "numeric", "logical"),
+                         defaultvalues = list(NULL, NULL, NULL, TRUE),
+                         required = c(TRUE, TRUE, FALSE, FALSE))
+    attrarg <- a$attrname
+  } else {
+    ### Check the network and arguments to make sure they are appropriate.
+    a <- check.ErgmTerm (nw, arglist, directed=FALSE, bipartite=TRUE,
+                         varnames = c("k", "attr", "base", "diff"),
+                         vartypes = c("numeric", ERGM_VATTR_SPEC, "numeric", "logical"),
+                         defaultvalues = list(NULL, NULL, NULL, TRUE),
+                         required = c(TRUE, TRUE, FALSE, FALSE))
+    attrarg <- a$attr
+  }
   ### Process the arguments
   nb1 <- get.network.attribute(nw, "bipartite")
-  nodecov <- get.node.attr(nw, a$attrname)
-  u <- NVL(a$levels, sort(unique(nodecov)))
+  nodecov <- ergm_get_vattr(attrarg, nw)
+  attrname <- attr(nodecov, "name")
+  u <- sort(unique(nodecov))
   # Recode to numeric
   nodecov <- match(nodecov,u,nomatch=length(u)+1)
   if (length(a$k) > 1) 
@@ -717,7 +729,7 @@ InitErgmTerm.b1starmix <- function(nw, arglist, ...) {
     u <- cbind(rep(1:nr,nc), nr + rep(1:nc, each=nr))
     if (any(NVL(a$base,0)!=0)) { u <- u[-a$base,] }
     name <- "b1starmix"
-    coef.names <- paste("b1starmix", a$k, a$attrname,
+    coef.names <- paste("b1starmix", a$k, attrname,
                         apply(matrix(namescov[u],ncol=2), 1,paste,collapse="."), 
                         sep=".")
     inputs <- c(a$k, nodecov, u[,1], u[,2])
@@ -727,7 +739,7 @@ InitErgmTerm.b1starmix <- function(nw, arglist, ...) {
     u <- 1:nr
     if (any(NVL(a$base,0)!=0)) { u <- u[-a$base] }
     name <- "b1starmixhomophily"
-    coef.names <- paste("b1starmix", a$k, a$attrname, namescov[u], sep=".")
+    coef.names <- paste("b1starmix", a$k, attrname, namescov[u], sep=".")
     inputs <- c(a$k, nodecov, u)
     attr(inputs, "ParamsBeforeCov") <- length(a$k) # should be 1
   }
@@ -1164,18 +1176,29 @@ InitErgmTerm.b2star <- function(nw, arglist, ..., version=packageVersion("ergm")
 }
 
 ################################################################################
-InitErgmTerm.b2starmix <- function(nw, arglist, ...) {
-  ### Check the network and arguments to make sure they are appropriate.
-  a <- check.ErgmTerm (nw, arglist, directed=FALSE, bipartite=TRUE,
-                       varnames = c("k", "attrname", "base", "diff", "levels"),
-                       vartypes = c("numeric", "character", "numeric", "logical", "character,numeric,logical"),
-                       defaultvalues = list(NULL, NULL, NULL, TRUE, NULL),
-                       required = c(TRUE, TRUE, FALSE, FALSE, FALSE))
+InitErgmTerm.b2starmix <- function(nw, arglist, ..., version=packageVersion("ergm")) {
+  if(version <= as.package_version("3.9.4")){
+    ### Check the network and arguments to make sure they are appropriate.
+    a <- check.ErgmTerm (nw, arglist, directed=FALSE, bipartite=TRUE,
+                         varnames = c("k", "attrname", "base", "diff"),
+                         vartypes = c("numeric", "character", "numeric", "logical"),
+                         defaultvalues = list(NULL, NULL, NULL, TRUE),
+                         required = c(TRUE, TRUE, FALSE, FALSE))
+    attrarg <- a$attrname
+  } else {
+    ### Check the network and arguments to make sure they are appropriate.
+    a <- check.ErgmTerm (nw, arglist, directed=FALSE, bipartite=TRUE,
+                         varnames = c("k", "attr", "base", "diff"),
+                         vartypes = c("numeric", ERGM_VATTR_SPEC, "numeric", "logical"),
+                         defaultvalues = list(NULL, NULL, NULL, TRUE),
+                         required = c(TRUE, TRUE, FALSE, FALSE))
+    attrarg <- a$attr
+  }
   ### Process the arguments
   nb1 <- get.network.attribute(nw, "bipartite")
-  nodecov <- get.node.attr(nw, a$attrname)
-  u <- NVL(a$levels, sort(unique(nodecov)))
-
+  nodecov <- ergm_get_vattr(attrarg, nw)
+  attrname <- attr(nodecov, "name")
+  u <- sort(unique(nodecov))
   # Recode to numeric
   nodecov <- match(nodecov,u,nomatch=length(u)+1)
   if (length(a$k) > 1) 
@@ -1192,7 +1215,7 @@ InitErgmTerm.b2starmix <- function(nw, arglist, ...) {
     u <- cbind(rep(1:nr,nc), nr + rep(1:nc, each=nr))
     if (any(NVL(a$base,0)!=0)) { u <- u[-a$base,] }
     name <- "b2starmix"
-    coef.names <- paste("b2starmix", a$k, a$attrname,
+    coef.names <- paste("b2starmix", a$k, attrname,
                         apply(matrix(namescov[u[,2:1]],ncol=2), 1,paste,collapse="."), 
                         sep=".")
     inputs <- c(a$k, nodecov, u[,1], u[,2])
@@ -1202,7 +1225,7 @@ InitErgmTerm.b2starmix <- function(nw, arglist, ...) {
     u <- nr+(1:nc)
     if (any(NVL(a$base,0)!=0)) { u <- u[-a$base] }
     name <- "b2starmixhomophily"
-    coef.names <- paste("b2starmix", a$k, a$attrname, namescov[u], sep=".")
+    coef.names <- paste("b2starmix", a$k, attrname, namescov[u], sep=".")
     inputs <- c(a$k, nodecov, u)
     attr(inputs, "ParamsBeforeCov") <- length(a$k) # should be 1
   }

--- a/man/ergm-terms.Rd
+++ b/man/ergm-terms.Rd
@@ -557,31 +557,27 @@
       undirected bipartite networks. Note that \code{b1star(1)} is equal to
       \code{b2star(1)} and to \code{edges}.}
 
-    \item{\code{b1starmix(k, attrname, base=NULL, diff=TRUE, levels=NULL)}  (binary)  (bipartite)  (undirected) (categorical nodal attribute)
+    \item{\code{b1starmix(k, attr, base=NULL, diff=TRUE)}  (binary)  (bipartite)  (undirected) (categorical nodal attribute)
     }{\emph{ Mixing
 	matrix for k-stars centered on the first mode of a bipartite network:} Only
       a single value of \eqn{k} is allowed. This term counts all k-stars in which
       the b2 nodes (called events in some contexts) are homophilous in the sense
-      that they all share the same value of \code{attrname}. However, the b1 node
+      that they all share the same value of \code{attr}. However, the b1 node
       (in some contexts, the actor) at the center of the k-star does NOT have to
       have the same value as the b2 nodes; indeed, the values taken by the b1
       nodes may be completely distinct from those of the b2 nodes, which allows
       for the use of this term in cases where there are two separate nodal
       attributes, one for the b1 nodes and another for the b2 nodes (in this case,
       however, these two attributes should be combined to form a single nodal
-      attribute called \code{attrname}. A different statistic is created for each
-      value of \code{attrname} seen in a b1 node, even if no k-stars are observed
+      attribute, \code{attr}). A different statistic is created for each
+      value of \code{attr} seen in a b1 node, even if no k-stars are observed
       with this value. Whether a different statistic is created for each value
       seen in a b2 node depends on the value of the \code{diff} argument: When
       \code{diff=TRUE}, the default, a different statistic is created for each
       value and thus the behavior of this term is reminiscent of the
       \code{nodemix} term, from which it takes its name; when \code{diff=FALSE},
       all homophilous k-stars are counted together, though these k-stars are still
-      categorized according to the value of the central b1 node.
-
-      \LevelsExplain{b1starmix}  By default, all levels are included.
-
-      \BaseDep}
+      categorized according to the value of the central b1 node.}
 
     \item{\code{b1twostar(b1attr, b2attr, base=NULL, b1levels=NULL, b2levels=NULL, levels2=NULL)}  (binary) (bipartite)  (undirected) (categorical nodal attribute)
     }{\emph{ Two-star
@@ -774,7 +770,7 @@
       undirected bipartite networks. Note that \code{b2star(1)} is equal to
       \code{b1star(1)} and to \code{edges}.}
 
-    \item{\code{b2starmix(k, attrname, base=NULL, diff=TRUE, levels=NULL)}  (binary)  (bipartite)  (undirected) (categorical nodal attribute)
+    \item{\code{b2starmix(k, attr, base=NULL, diff=TRUE)}  (binary)  (bipartite)  (undirected) (categorical nodal attribute)
     }{\emph{ Mixing
 	matrix for k-stars centered on the second mode of a bipartite network:}
       This term is exactly the same as \code{b1starmix} except that the roles of


### PR DESCRIPTION
remove levels from starmix because it wasn't working

convert attrname to attr (and use new UI)

docs updated appropriately

as with balance I made an independent implementation of the statistic calculation in R and it matched ergm's calculation so the core of the term code is fine (just not the levels argument, which is now gone)

no additions (in particular, no replacement levels argument, or additional levels2 argument) were made as I was instructed to minimize time spent on these terms

NB: these two terms are now somewhat out of sync with the rest due to the lack of levels/levels2 arguments (but as far as we know no one is using them); anyone using this term will have to use base for the time being