### PR TITLE
add a little space to the hash table (in some circumstances)

### DIFF
--- a/R/ergm.pl.R
+++ b/R/ergm.pl.R
@@ -42,7 +42,7 @@ ergm.pl<-function(nw, fd, m, theta.offset=NULL,
   e <- sum(elfd)
 
   maxNumDyadTypes <- min(if(is.function(control$MPLE.max.dyad.types)) control$MPLE.max.dyad.types(d=d, e=e) else control$MPLE.max.dyad.types,
-                         d)
+                         1.05*d) # a little larger than d so the hash table doesn't bog down
   maxDyads <- if(is.function(control$MPLE.samplesize)) control$MPLE.samplesize(d=d, e=e) else control$MPLE.samplesize
 
   z <- .C("MPLE_wrapper",

--- a/R/ergm.pl.R
+++ b/R/ergm.pl.R
@@ -41,8 +41,8 @@ ergm.pl<-function(nw, fd, m, theta.offset=NULL,
   elfd <- as.rlebdm(el) & fd
   e <- sum(elfd)
 
-  maxNumDyadTypes <- min(if(is.function(control$MPLE.max.dyad.types)) control$MPLE.max.dyad.types(d=d, e=e) else control$MPLE.max.dyad.types,
-                         1.05*d) # a little larger than d so the hash table doesn't bog down
+  maxNumDyadTypes <- as.integer(min(if(is.function(control$MPLE.max.dyad.types)) control$MPLE.max.dyad.types(d=d, e=e) else control$MPLE.max.dyad.types,
+                         1.05*d)) # a little larger than d so the hash table doesn't bog down
   maxDyads <- if(is.function(control$MPLE.samplesize)) control$MPLE.samplesize(d=d, e=e) else control$MPLE.samplesize
 
   z <- .C("MPLE_wrapper",


### PR DESCRIPTION
references statnet/ergm#179

A 5% increase in allocation makes > 100x speedup in the following `predict` call (and others like it):

```
require(ergm)
nw <- network.initialize(15000,dir=F)
nw <- san(nw ~ edges, target.stats=15000)
fit <- ergm(nw ~ edges)
st <- Sys.time()
pnet <- predict(fit)
et <- Sys.time()
print(et - st)
```
