### PR TITLE
Makes predict function return right predicted adjacency matrices for undirected networks.

### DIFF
--- a/R/predict.ergm.R
+++ b/R/predict.ergm.R
@@ -82,7 +82,25 @@ predict.formula <- function(object, theta,
   
   # Transform extended ergmMPLE() output to matrix with 0s on the diagonal
   .df_to_matrix <- function(d) {
-    res <- tapply(predmat[,"p"], list(predmat[,"tail"], predmat[,"head"]), identity)
+    # Store tail and head vertex id and tie probability
+    tail <- d[, "tail"]
+    head <- d[, "head"]
+    p <- d[, "p"]
+    # Get the minimum and maximum vertex ids
+    vertexid_min <- min(tail)
+    vertexid_max <- max(head)
+    # Add loops for vertexid_min and vertexid_max to avoid the issue for undirected networks.
+    tail <- c(vertexid_min, tail, vertexid_max)
+    head <- c(vertexid_min, head, vertexid_max)
+    p <- c(0, p, 0)
+    # Get predicted adjacency matrix
+    res <- tapply(p, list(tail, head), identity)
+    # If undirected, replace the lower triangular matrix elements of the predicted adjacency matrix
+    if (is.na(res[nodeid_max, nodeid_min])) {
+      res[lower.tri(res)] <- 0
+      res <- res + t(res)
+    }
+    # Put zeros in the diagonals.
     diag(res) <- 0
     res
   }


### PR DESCRIPTION
# Issue
`predict` function doesn't yield correct predicted adjacency matrices for undirected networks.

# Example to replicate the bug

```
library(ergm)

# Prepare a network
g <- network::network.initialize(n = 3, directed = FALSE)
network::add.edges(g, tail = c(1, 2), head = c(2, 3))
network::set.vertex.attribute(g, attrname = "x", value = rnorm(3))

# Estimate logit
logit <- ergm(formula = g ~ edges + absdiff("x"),
              estimate = "MPLE")

# Get a predicted adjacency matrix
predicted_adj <- predict(logit, output = "matrix")

# This should be a 3 x 3 matrix, but...
predicted_adj
```

```
> predicted_adj
   2            3
1  0 4.607926e-11
2 NA 0.000000e+00
```

# Cause of the bug
This bug comes from `.df_to_matrix` function in `predict.formula`. 

For undirected networks `tail` doesn't contain the last vertex id (3 in the above example), while `head` doesn't have the first vertex id (1 in the example).
Moreover, the lower triangle elements are missing for undirected networks.

# Solution
To fix this bug, I added both the first and last vertex ids to `tail` and `head`. 
And when the bottom-left element of the predicted adjacency matrix is missing (this means the network is undirected), the modified function makes it symmetric.