### PR TITLE
Fix returning predicted probabilities as a matrix

### DIFF
--- a/R/predict.ergm.R
+++ b/R/predict.ergm.R
@@ -82,7 +82,8 @@ predict.formula <- function(object, theta,
   
   # Transform extended ergmMPLE() output to matrix with 0s on the diagonal
   .df_to_matrix <- function(d) {
-    res <- tapply(predmat[,"p"], list(predmat[,"tail"], predmat[,"head"]), identity)
+    N <- max(predmat[,c("tail", "head")])
+    res <- replace(matrix(NA, N, N), as.matrix(d[,c("tail", "head")]), d[,"p"])
     diag(res) <- 0
     res
   }

--- a/tests/testthat/test-predict.ergm.R
+++ b/tests/testthat/test-predict.ergm.R
@@ -187,18 +187,3 @@ test_that("it works for offsets and non-finite offset coefs", {
     all(is.finite(p$p))
   )
 })
-
-
-
-
-test_that("issue 199 is resolved", {
-  g <- network::network.initialize(n = 3, directed = FALSE)
-  network::add.edges(g, tail = c(1, 2), head = c(2, 3))
-  network::set.vertex.attribute(g, attrname = "x", value = rnorm(3))
-  logit <- ergm(formula = g ~ edges + absdiff("x"), estimate = "MPLE")
-  predicted_adj <- predict(logit, output = "matrix")
-  expect_identical(
-    dim(predicted_adj),
-    c(3L, 3L)
-  )
-})

--- a/tests/testthat/test-predict.ergm.R
+++ b/tests/testthat/test-predict.ergm.R
@@ -187,3 +187,18 @@ test_that("it works for offsets and non-finite offset coefs", {
     all(is.finite(p$p))
   )
 })
+
+
+
+
+test_that("issue 199 is resolved", {
+  g <- network::network.initialize(n = 3, directed = FALSE)
+  network::add.edges(g, tail = c(1, 2), head = c(2, 3))
+  network::set.vertex.attribute(g, attrname = "x", value = rnorm(3))
+  logit <- ergm(formula = g ~ edges + absdiff("x"), estimate = "MPLE")
+  predicted_adj <- predict(logit, output = "matrix")
+  expect_identical(
+    dim(predicted_adj),
+    c(3L, 3L)
+  )
+})


### PR DESCRIPTION
This closes statnet/ergm#199 by using `replace()` in `.df_to_matrix()` to fill-in a square adjacency matrix with the predicted probabilities.