### PR TITLE
Fix row/colnames of matrix output of predict.formula()

### DIFF
--- a/R/predict.ergm.R
+++ b/R/predict.ergm.R
@@ -129,7 +129,11 @@ predict.formula <- function(object, theta,
   switch(
     output,
     data.frame = as.data.frame(predmat[,c("tail", "head", "p")]),
-    matrix = .df_to_matrix(predmat)
+    matrix = {
+      # Get vertex names
+      vnames <- eval_lhs.formula(object) %v% "vertex.names"
+      structure(.df_to_matrix(predmat), dimnames = list(vnames, vnames))
+    }
   )
 }
 

--- a/R/predict.ergm.R
+++ b/R/predict.ergm.R
@@ -79,6 +79,7 @@ predict.formula <- function(object, theta,
   theta <- statnet.common::deInf(theta)
   output <- match.arg(output)
   type <- match.arg(type)
+  stopifnot(nsim >= 2)
   
   # Transform extended ergmMPLE() output to matrix with 0s on the diagonal
   .df_to_matrix <- function(d) {

--- a/R/predict.ergm.R
+++ b/R/predict.ergm.R
@@ -90,9 +90,12 @@ predict.formula <- function(object, theta,
   
   # Matrix to data.frame
   .matrix_to_df <- function(m, name=".value") {
+    unames <- sort(unique(unlist(dimnames(m))))
     d <- as.data.frame(as.table(m), stringsAsFactors=FALSE)
     names(d) <- c("tail", "head", name)
-    d
+    d$tail <- match(d$tail, unames)
+    d$head <- match(d$head, unames)
+    subset(d, tail != head)
   }
   
   # Simulated unconditional Ps

--- a/R/predict.ergm.R
+++ b/R/predict.ergm.R
@@ -99,7 +99,7 @@ predict.formula <- function(object, theta,
   if(!conditional) {
     if(type != "response") 
       stop("type='link' for unconditional probabilities is not supported")
-    predm <- predict_ergm_unconditional(object=object, coef=theta, nsim=100, ...)
+    predm <- predict_ergm_unconditional(object=object, coef=theta, nsim=nsim, ...)
     return(
       switch(
         output,

--- a/tests/testthat/test-predict.ergm.R
+++ b/tests/testthat/test-predict.ergm.R
@@ -187,3 +187,16 @@ test_that("it works for offsets and non-finite offset coefs", {
     all(is.finite(p$p))
   )
 })
+
+
+test_that("matrix output of predict() is properly named", {
+  data(g4)
+  set.seed(666)
+  fit <- ergm(g4 ~ edges)
+  p.cond <- predict(fit, conditional = TRUE, output = "matrix")
+  expect_identical(rownames(p.cond), g4 %v% "vertex.names")
+  expect_identical(colnames(p.cond), g4 %v% "vertex.names")
+  p.uncond <- predict(fit, conditional = FALSE, output = "matrix", nsim = 2)
+  expect_identical(rownames(p.uncond), g4 %v% "vertex.names")
+  expect_identical(colnames(p.uncond), g4 %v% "vertex.names")
+})


### PR DESCRIPTION
Matrix output is now always named with vertex names of the network object, This closes #226 .