### PR TITLE
Ergm 406

### DIFF
--- a/R/InitErgmConstraint.R
+++ b/R/InitErgmConstraint.R
@@ -61,14 +61,14 @@ InitErgmConstraint..attributes <- function(nw, arglist, ...){
     dependence = FALSE)
 }
 
-#' @name .dyads-ergmConstraint
+#' @templateVar name .dyads
 #' @title A meta-constraint indicating handling of arbitrary dyadic constraints
 #' @description This is a flag in the proposal table indicating that the proposal can enforce arbitrary combinations of dyadic constraints. It cannot be invoked directly by the user.
 #'
 #' @template ergmConstraint-general
 NULL
 
-#' @name edges-ergmConstraint
+#' @templateVar name edges
 #' @title Preserve the edge count of the given network
 #' @description Preserve the edge count of the given network
 #' @details Only networks
@@ -84,7 +84,7 @@ InitErgmConstraint.edges<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = "edges")
 }
 
-#' @name degrees-ergmConstraint
+#' @templateVar name degrees
 #' @title Preserve the degree of each vertex of the given network
 #' @description Preserve the degree of each vertex of the given network
 #' @details Only networks
@@ -110,7 +110,7 @@ InitErgmConstraint.degrees<-function(nw, arglist, ...){
 #' # nodedegrees
 InitErgmConstraint.nodedegrees<-InitErgmConstraint.degrees
 
-#' @name odegrees-ergmConstraint
+#' @templateVar name odegrees
 #' @title Preserve outdegree for directed networks
 #' @description Preserve outdegree for directed networks
 #' @details For directed networks, preserve the outdegree of each vertex of the given
@@ -127,7 +127,7 @@ InitErgmConstraint.odegrees<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = c("odegrees", "edges", "odegreedist"))
 }
 
-#' @name idegrees-ergmConstraint
+#' @templateVar name idegrees
 #' @title Preserve indegree for directed networks
 #' @description Preserve indegree for directed networks
 #' @details For directed networks, preserve the indegree of each vertex of the given
@@ -144,7 +144,7 @@ InitErgmConstraint.idegrees<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = c("idegrees", "edges", "idegreedist"))
 }
 
-#' @name b1degrees-ergmConstraint
+#' @templateVar name b1degrees
 #' @title Preserve the actor degree for bipartite networks
 #' @description Preserve the degree distribution for bipartite networks
 #' @details For bipartite networks, preserve the degree for the first mode of each vertex of the given
@@ -161,7 +161,7 @@ InitErgmConstraint.b1degrees<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = c("b1degrees", "edges"))
 }
 
-#' @name b2degrees-ergmConstraint
+#' @templateVar name b2degrees
 #' @title Preserve the receiver degree for bipartite networks
 #' @description Preserve the degree distribution for bipartite networks
 #' @details For bipartite networks, preserve the degree for the second mode of each vertex of the given
@@ -178,7 +178,7 @@ InitErgmConstraint.b2degrees<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = c("b2degrees", "edges"))
 }
 
-#' @name degreedist-ergmConstraint
+#' @templateVar name degreedist
 #' @title Preserve the degree distribution of the given network
 #' @description Preserve the degree distribution of the given network
 #' @details Only networks
@@ -197,7 +197,7 @@ InitErgmConstraint.degreedist<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = c("degreedist", "edges", "idegreedist", "odegreedist"))
 }
 
-#' @name idegreedist-ergmConstraint
+#' @templateVar name idegreedist
 #' @title Preserve the indegree distribution
 #' @description Preserve the indegree distribution
 #' @details Preserve the indegree distribution of the given network.
@@ -213,7 +213,7 @@ InitErgmConstraint.idegreedist<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = c("idegreedist", "edges"))
 }
 
-#' @name odegreedist-ergmConstraint
+#' @templateVar name odegreedist
 #' @title Preserve the outdegree distribution
 #' @description Preserve the outdegree distribution
 #' @details Preserve the outdegree distribution of the given network.
@@ -229,7 +229,7 @@ InitErgmConstraint.odegreedist<-function(nw, arglist, ...){
   list(dependence = TRUE, implies = c("odegreedist", "edges"))
 }
 
-#' @name bd-ergmConstraint
+#' @templateVar name bd
 #' @title Constrain maximum and minimum vertex degree
 #' @description Constrain maximum and minimum vertex degree
 #' @details Condition on the number of inedge or outedges posessed by a node. 
@@ -264,7 +264,7 @@ InitErgmConstraint.bd<-function(nw, arglist, ...){
    list(constrain=constrain, attribs=a$attribs, maxout=a$maxout, maxin=a$maxin, minout=a$minout, minin=a$minin)
 }
 
-#' @name blocks-ergmConstraint
+#' @templateVar name blocks
 #' @title Constrain "blocks" of dyads
 #' @description Constrain "blocks" of dyads
 #' @details Any dyad whose toggle would produce a nonzero change statistic for a `nodemix` term with the same arguments will be fixed. Note that the `levels2` argument has a different default value for `blocks` than it does for `nodemix` .
@@ -402,7 +402,7 @@ InitErgmConstraint.blocks <- function(nw, arglist, ...) {
 }
 
 
-#' @name hamming-ergmConstraint
+#' @templateVar name hamming
 #' @title TODO
 #' @description TODO
 #' @details TODO
@@ -418,7 +418,7 @@ InitErgmConstraint.hamming<-function(nw, arglist, ...){
   list(dependence = TRUE)
 }
 
-#' @name observed-ergmConstraint
+#' @templateVar name observed
 #' @title Preserve the observed dyads of the given network
 #' @description Preserve the observed dyads of the given network
 #' @details Preserve the observed dyads of the given network.
@@ -437,7 +437,7 @@ InitErgmConstraint.observed <- function(nw, arglist, ...){
        dependence = FALSE, implies = c("observed"))
 }
 
-#' @name fixedas-ergmConstraint
+#' @templateVar name fixedas
 #' @title Preserve and preclude edges
 #' @description Preserve and preclude edges
 #' @details Preserve the edges in 'present' and preclude the edges in 'absent'.
@@ -481,7 +481,7 @@ InitErgmConstraint.fixedas<-function(nw, arglist,...){
     dependence = FALSE)
 }
 
-#' @name fixallbut-ergmConstraint
+#' @templateVar name fixallbut
 #' @title Preserve the dyad status in all but the given edges
 #' @description Preserve the dyad status in all but the given edges
 #' @details Preserve the dyad status in all but `free.dyads`.
@@ -516,7 +516,7 @@ InitErgmConstraint.fixallbut<-function(nw, arglist,...){
     dependence = FALSE)
 }
 
-#' @name dyadnoise-ergmConstraint
+#' @templateVar name dyadnoise
 #' @title A soft constraint to adjust the sampled distribution for
 #'   dyad-level noise with known perturbation probabilities
 #' @description A soft constraint to adjust the sampled distribution for
@@ -554,7 +554,7 @@ InitErgmConstraint.dyadnoise<-function(nw, arglist, ...){
   list(p01=p01, p10=p10)
 }
 
-#' @name egocentric-ergmConstraint
+#' @templateVar name egocentric
 #' @title Preserve values of dyads incident on vertices with given attribute
 #' @description Preserve values of dyads incident on vertices with given attribute
 #' @details Preserve values of dyads incident on vertices with attribute `attr` being `TRUE` or if `attrname` is `NULL` , the vertex attribute `"na"` being `FALSE`.
@@ -603,7 +603,7 @@ InitErgmConstraint.egocentric <- function(nw, arglist, ...){
   )
 }
 
-#' @name Dyads-ergmConstraint
+#' @templateVar name Dyads
 #' @title Constrain fixed or varying dyad-independent terms
 #' @description This is an "operator" constraint that takes one or two [`ergmTerm`] dyad-independent formulas. For the terms in the `vary=` formula, only those that change at least one of the terms will be allowed to vary, and all others will be fixed. If both formulas are given, the dyads that vary either for one or for the other will be allowed to vary. Note that a formula passed to `Dyads` without an argument name will default to `fix=` .
 #'

--- a/R/InitErgmConstraint.blockdiag.R
+++ b/R/InitErgmConstraint.blockdiag.R
@@ -41,7 +41,7 @@
   list(values=o, lengths1=l1, lengths2=l2)
 }
 
-#' @name blockdiag-ergmConstraint
+#' @templateVar name blockdiag
 #' @title Force a block-diagonal structure on the network
 #' @description Force a block-diagonal structure (and its bipartite analogue) on the network
 #' @details  Only dyads \eqn{(i,j)} for which `attr(i)==attr(j)` can have edges. 

--- a/R/InitErgmConstraint.hints.R
+++ b/R/InitErgmConstraint.hints.R
@@ -12,7 +12,7 @@ InitErgmConstraint.TNT<-function(nw, arglist, ...){
   InitErgmConstraint.sparse(nw, arglist, ...)
 }
 
-#' @name sparse-ergmHint
+#' @templateVar name sparse
 #' @aliases sparse-ergmConstraint
 #' @title Sparse network
 #' @description The network is sparse. This typically results in a Tie-Non-Tie (TNT) proposal regime.
@@ -20,7 +20,7 @@ InitErgmConstraint.TNT<-function(nw, arglist, ...){
 #' @usage
 #' # sparse
 #'
-#' @template ergmConstraint-general
+#' @template ergmHint-general
 #'
 #' @concept dyad-independent
 InitErgmConstraint.sparse<-function(nw, arglist, ...){
@@ -33,7 +33,7 @@ InitErgmConstraint.Strat<-function(nw, arglist, ...){
   InitErgmConstraint.strat(nw, arglist, ...)
 }
 
-#' @name strat-ergmHint
+#' @templateVar name strat
 #' @aliases strat-ergmConstraint
 #' @title Stratified dyads
 #' @description The dyads in the network are stratified according to

--- a/R/InitErgmReference.R
+++ b/R/InitErgmReference.R
@@ -8,7 +8,7 @@
 #  Copyright 2003-2021 Statnet Commons
 #######################################################################
 
-#' @name Bernoulli-ergmReference
+#' @templateVar name Bernoulli
 #' @title Bernoulli reference
 #' @description Bernoulli reference
 #' @details Specifies each
@@ -30,7 +30,7 @@ InitErgmReference.Bernoulli <- function(nw, arglist, ...){
   list(name="Bernoulli", init_methods=c("MPLE", "CD", "zeros"))
 }
 
-#' @name StdNormal-ergmReference
+#' @templateVar name StdNormal
 #' @title Standard Normal reference
 #' @description Standard Normal reference
 #' @details Specifies each dyad's baseline distribution to be the normal distribution
@@ -47,7 +47,7 @@ InitErgmReference.StdNormal <- function(nw, arglist, ...){
   list(name="StdNormal", init_methods=c("CD","zeros"))
 }
 
-#' @name Unif-ergmReference
+#' @templateVar name Unif
 #' @title Continuous Uniform reference
 #' @description Continuous Uniform reference
 #' @details Specifies each dyad's baseline distribution to be continuous uniform
@@ -69,7 +69,7 @@ InitErgmReference.Unif <- function(nw, arglist, ...){
   list(name="Unif", arguments=list(a=a$a, b=a$b), init_methods=c("CD","zeros"))
 }
 
-#' @name DiscUnif-ergmReference
+#' @templateVar name DiscUnif
 #' @title Discrete Uniform reference
 #' @description Discrete Uniform reference
 #' @details Specifies each dyad's baseline distribution to be discrete uniform

--- a/R/InitErgmTerm.R
+++ b/R/InitErgmTerm.R
@@ -168,7 +168,7 @@ LEVELS_BASE1 <- NULL
 
 ################################################################################
 
-#' @name absdiff-ergmTerm
+#' @templateVar name absdiff
 #' @title Absolute difference
 #' @description Absolute difference in nodal attribute.
 #' @details This term adds one network statistic to the model equaling
@@ -223,7 +223,7 @@ InitErgmTerm.absdiff <- function(nw, arglist, ..., version=packageVersion("ergm"
 
 ################################################################################
 
-#' @name absdiffcat-ergmTerm
+#' @templateVar name absdiffcat
 #' @title Categorical absolute difference
 #' @description Categorical absolute difference in nodal attribute.
 #' @details This term adds one statistic for every possible nonzero distinct
@@ -294,7 +294,7 @@ InitErgmTerm.absdiffcat <- function(nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name altkstar-ergmTerm
+#' @templateVar name altkstar
 #' @title Alternating k-star
 #' @description Add one network statistic to the model equal to a weighted alternating
 #'   sequence of k-star statistics with weight parameter `lambda`.
@@ -365,7 +365,7 @@ InitErgmTerm.altkstar <- function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name asymmetric-ergmTerm
+#' @templateVar name asymmetric
 #' @title Asymmetric dyads
 #' @description Asymmetric dyads
 #' @details This term adds one network statistic to the model equal to the
@@ -444,7 +444,7 @@ InitErgmTerm.asymmetric <- function(nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name attrcov-ergmTerm
+#' @templateVar name attrcov
 #' @title Edge covariate by attribute pairing
 #' @description Edge covariate by attribute pairing
 #' 
@@ -519,7 +519,7 @@ InitErgmTerm.attrcov <- function (nw, arglist, ..., version=packageVersion("ergm
 
 ################################################################################
 
-#' @name b1concurrent-ergmTerm
+#' @templateVar name b1concurrent
 #' @title Concurrent node count for the first mode in a bipartite network
 #' @description Concurrent node count for the first mode in a bipartite network
 #' @details This term adds one
@@ -594,7 +594,7 @@ InitErgmTerm.b1concurrent<-function(nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name b1degrange-ergmTerm
+#' @templateVar name b1degrange
 #' @title Degree range for the first mode in a bipartite network
 #' @description Degree range for the first mode in a bipartite (a.k.a. two-mode) network
 #' @details This term adds one
@@ -711,7 +711,7 @@ InitErgmTerm.b1degrange<-function(nw, arglist, ..., version=packageVersion("ergm
 
 ################################################################################
 
-#' @name b1cov-ergmTerm
+#' @templateVar name b1cov
 #' @title Main effect of a covariate for the first mode in a bipartite network
 #' @description Main effect of a covariate for the first mode in a bipartite (aka two-mode) network
 #' @details This term adds a single network statistic for each quantitative attribute or matrix column to the model equaling the total
@@ -766,7 +766,7 @@ InitErgmTerm.b1cov<-function (nw, arglist, ..., version=packageVersion("ergm")) 
 
 ################################################################################
 
-#' @name b1degree-ergmTerm
+#' @templateVar name b1degree
 #' @title Degree for the first mode in a bipartite network
 #' @description Degree for the first mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model for
@@ -853,7 +853,7 @@ InitErgmTerm.b1degree <- function(nw, arglist, ..., version=packageVersion("ergm
 
 ################################################################################
 
-#' @name b1dsp-ergmTerm
+#' @templateVar name b1dsp
 #' @title Dyadwise shared partners for dyads in the first bipartition
 #' @description Dyadwise shared partners for dyads in the first bipartition
 #' @details This term adds one
@@ -899,7 +899,7 @@ InitErgmTerm.b1dsp<-function(nw, arglist, cache.sp=TRUE, ...) {
 
 ################################################################################
 
-#' @name b1factor-ergmTerm
+#' @templateVar name b1factor
 #' @title Factor attribute effect for the first mode in a bipartite network
 #' @description Factor attribute effect for the first mode in a bipartite (aka two-mode) network
 #' @details This term adds multiple network statistics to the model, one for each of (a subset of) the
@@ -975,7 +975,7 @@ InitErgmTerm.b1factor<-function (nw, arglist, ..., version=packageVersion("ergm"
 
 ################################################################################
 
-#' @name b1sociality-ergmTerm
+#' @templateVar name b1sociality
 #' @title Degree
 #' @description Degree
 #' @details This term adds one network statistic for each node in the first bipartition, equal to the number of
@@ -1020,7 +1020,7 @@ InitErgmTerm.b1sociality<-function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name b1star-ergmTerm
+#' @templateVar name b1star
 #' @title k-Stars for the first mode in a bipartite network
 #' @description k-Stars for the first mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model for
@@ -1092,7 +1092,7 @@ InitErgmTerm.b1star <- function(nw, arglist, ..., version=packageVersion("ergm")
 
 ################################################################################
 
-#' @name b1starmix-ergmTerm
+#' @templateVar name b1starmix
 #' @title Mixing matrix for k-stars centered on the first mode of a bipartite network
 #' @description Mixing matrix for k-stars centered on the first mode of a bipartite network
 #' @details This term counts all k-stars in which
@@ -1187,7 +1187,7 @@ InitErgmTerm.b1starmix <- function(nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name b1twostar-ergmTerm
+#' @templateVar name b1twostar
 #' @title Two-star census for central nodes centered on the first mode of a bipartite network
 #' @description Two-star census for central nodes centered on the first mode of a bipartite network
 #' @details This term takes two nodal attributes. Assuming that there are
@@ -1283,7 +1283,7 @@ InitErgmTerm.b1twostar <- function(nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name b2concurrent-ergmTerm
+#' @templateVar name b2concurrent
 #' @title Concurrent node count for the second mode in a bipartite network
 #' @description Concurrent node count for the second mode in a bipartite (aka two-mode) network
 #' @details This term adds one
@@ -1354,7 +1354,7 @@ InitErgmTerm.b2concurrent<-function(nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name b2cov-ergmTerm
+#' @templateVar name b2cov
 #' @title Main effect of a covariate for the second mode in a bipartite  network
 #' @description Main effect of a covariate for the second mode in a bipartite (aka two-mode) network
 #' @details This term adds a single network statistic for each quantitative attribute or matrix column to the model equaling the total
@@ -1407,7 +1407,7 @@ InitErgmTerm.b2cov<-function (nw, arglist, ..., version=packageVersion("ergm")) 
 
 ################################################################################
 
-#' @name b2degrange-ergmTerm
+#' @templateVar name b2degrange
 #' @title Degree range for the second mode in a bipartite network
 #' @description Degree range for the second mode in a bipartite (a.k.a. two-mode) network
 #' @details This term adds one
@@ -1525,7 +1525,7 @@ InitErgmTerm.b2degrange<-function(nw, arglist, ..., version=packageVersion("ergm
 
 ################################################################################
 
-#' @name b2degree-ergmTerm
+#' @templateVar name b2degree
 #' @title Degree for the second mode in a bipartite network
 #' @description Degree for the second mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model for
@@ -1609,7 +1609,7 @@ InitErgmTerm.b2degree <- function(nw, arglist, ..., version=packageVersion("ergm
 
 ################################################################################
 
-#' @name b2dsp-ergmTerm
+#' @templateVar name b2dsp
 #' @title Dyadwise shared partners for dyads in the second bipartition
 #' @description Dyadwise shared partners for dyads in the second bipartition
 #' @details This term adds one network statistic to the model for each element in `d` ; the \eqn{i} th
@@ -1653,7 +1653,7 @@ InitErgmTerm.b2dsp<-function(nw, arglist, cache.sp=TRUE, ...) {
 
 ################################################################################
 
-#' @name b2factor-ergmTerm
+#' @templateVar name b2factor
 #' @title Factor attribute effect for the second mode in a bipartite network
 #' @description Factor attribute effect for the second mode in a bipartite (aka two-mode) network
 #' @details This term adds multiple network statistics to the model, one for each of (a subset of) the
@@ -1730,7 +1730,7 @@ InitErgmTerm.b2factor<-function (nw, arglist, ..., version=packageVersion("ergm"
 
 ################################################################################
 
-#' @name b2sociality-ergmTerm
+#' @templateVar name b2sociality
 #' @title Degree
 #' @description Degree
 #' @details This term adds one network statistic for each node in the second bipartition, equal to the number of
@@ -1777,7 +1777,7 @@ InitErgmTerm.b2sociality<-function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name b2star-ergmTerm
+#' @templateVar name b2star
 #' @title k-Stars for the second mode in a bipartite network
 #' @description k-Stars for the second mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model for
@@ -1850,7 +1850,7 @@ InitErgmTerm.b2star <- function(nw, arglist, ..., version=packageVersion("ergm")
 
 ################################################################################
 
-#' @name b2starmix-ergmTerm
+#' @templateVar name b2starmix
 #' @title Mixing matrix for k-stars centered on the second mode of a bipartite network
 #' @description Mixing matrix for k-stars centered on the second mode of a bipartite network
 #' @details This term is exactly the same as `b1starmix` except that the roles of
@@ -1934,7 +1934,7 @@ InitErgmTerm.b2starmix <- function(nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name b2twostar-ergmTerm
+#' @templateVar name b2twostar
 #' @title Two-star census for central nodes centered on the second mode of a bipartite network
 #' @description Two-star census for central nodes centered on the second mode of a bipartite network
 #' @details This term is exactly the same as `b1twostar` except that the
@@ -2026,7 +2026,7 @@ InitErgmTerm.b2twostar <- function(nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name balance-ergmTerm
+#' @templateVar name balance
 #' @title Balanced triads
 #' @description Balanced triads
 #' @details This term adds one network statistic to the model equal to the number of
@@ -2056,7 +2056,7 @@ InitErgmTerm.balance<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name concurrent-ergmTerm
+#' @templateVar name concurrent
 #' @title Concurrent node count
 #' @description Concurrent node count
 #' @details This term adds one network statistic to the model, equal to the number of
@@ -2121,7 +2121,7 @@ InitErgmTerm.concurrent<-function(nw, arglist, ..., version=packageVersion("ergm
 
 ################################################################################
 
-#' @name ctriple-ergmTerm
+#' @templateVar name ctriple
 #' @title Cyclic triples
 #' @description Cyclic triples
 #' @details By default, this term adds one
@@ -2201,7 +2201,7 @@ InitErgmTerm.ctriad<-InitErgmTerm.ctriple
 
 ################################################################################
 
-#' @name cycle-ergmTerm
+#' @templateVar name cycle
 #' @title k-Cycle Census
 #' @description k-Cycle Census
 #' @details This term adds one network statistic to the model for each value of `k` ,
@@ -2277,7 +2277,7 @@ InitErgmTerm.cycle <- function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name degcor-ergmTerm
+#' @templateVar name degcor
 #' @title Degree Correlation
 #' @description Degree Correlation
 #' @details This term adds one network statistic equal to the correlation
@@ -2309,7 +2309,7 @@ InitErgmTerm.degcor<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name degcrossprod-ergmTerm
+#' @templateVar name degcrossprod
 #' @title Degree Cross-Product
 #' @description Degree Cross-Product
 #' @details This term adds one network statistic equal to the mean of the cross-products
@@ -2334,7 +2334,7 @@ InitErgmTerm.degcrossprod<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name degrange-ergmTerm
+#' @templateVar name degrange
 #' @title Degree range
 #' @description Degree range
 #' @details This term adds one
@@ -2448,7 +2448,7 @@ InitErgmTerm.degrange<-function(nw, arglist, ..., version=packageVersion("ergm")
 
 ################################################################################
 
-#' @name degree-ergmTerm
+#' @templateVar name degree
 #' @title Degree
 #' @description Degree
 #' @details This term adds one
@@ -2538,7 +2538,7 @@ InitErgmTerm.degree<-function(nw, arglist, ..., version=packageVersion("ergm")) 
 
 ################################################################################
 
-#' @name degree1.5-ergmTerm
+#' @templateVar name degree1.5
 #' @title Degree to the 3/2 power
 #' @description Degree to the 3/2 power
 #' @details This term adds one network statistic to the model equaling the sum over
@@ -2581,7 +2581,7 @@ InitErgmTerm.degreepopularity<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name density-ergmTerm
+#' @templateVar name density
 #' @title Density
 #' @description Density
 #' @details This term adds one network statistic equal to the density of the network.
@@ -2609,7 +2609,7 @@ InitErgmTerm.density<-function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name diff-ergmTerm
+#' @templateVar name diff
 #' @title Difference
 #' @description Difference
 #' @details For values of `pow` other than
@@ -2709,7 +2709,7 @@ InitErgmTerm.diff <- function(nw, arglist, ..., version=packageVersion("ergm")) 
 
 ################################################################################
 
-#' @name dsp-ergmTerm
+#' @templateVar name dsp
 #' @title Dyadwise shared partners
 #' @description Dyadwise shared partners
 #' @details This term adds one
@@ -2765,7 +2765,7 @@ InitErgmTerm.dsp<-function(nw, arglist, cache.sp=TRUE, ...) {
 
 ################################################################################
 
-#' @name dyadcov-ergmTerm
+#' @templateVar name dyadcov
 #' @title Dyadic covariate
 #' @description Dyadic covariate
 #' @details #'   This term adds three statistics to the model, each equal to the sum of the
@@ -2847,7 +2847,7 @@ InitErgmTerm.dyadcov<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name edgecov-ergmTerm
+#' @templateVar name edgecov
 #' @title Edge covariate
 #' @description Edge covariate
 #' @details This term adds one statistic to the model, equal to the sum
@@ -2907,7 +2907,7 @@ InitErgmTerm.edgecov <- function(nw, arglist, ...) {
 ################################################################################
 
 
-#' @name edges-ergmTerm
+#' @templateVar name edges
 #' @title Edges
 #' @description Number of edges in the network.
 #' @details This term adds one network statistic equal to the number of
@@ -2938,7 +2938,7 @@ InitErgmTerm.edges<-function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name esp-ergmTerm
+#' @templateVar name esp
 #' @title Edgewise shared partners
 #' @description Edgewise shared partners
 #' @details This is just like the `dsp` term, except this term adds one network
@@ -2981,7 +2981,7 @@ InitErgmTerm.esp<-function(nw, arglist, cache.sp=TRUE, ...) {
 
 ################################################################################
 
-#' @name gwb1degree-ergmTerm
+#' @templateVar name gwb1degree
 #' @title Geometrically weighted degree distribution for the first mode in a bipartite network
 #' @description Geometrically weighted degree distribution for the first mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model equal to the weighted
@@ -3080,7 +3080,7 @@ InitErgmTerm.gwb1degree<-function(nw, arglist, gw.cutoff=30, ..., version=packag
 
 ################################################################################
 
-#' @name gwb1dsp-ergmTerm
+#' @templateVar name gwb1dsp
 #' @title Geometrically weighted dyadwise shared partner distribution for dyads in the first bipartition
 #' @description Geometrically weighted dyadwise shared partner distribution for dyads in the first bipartition
 #' @details This term adds one network statistic to the model equal to the geometrically
@@ -3139,7 +3139,7 @@ InitErgmTerm.gwb1dsp<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...) {
 
 ################################################################################
 
-#' @name gwb2degree-ergmTerm
+#' @templateVar name gwb2degree
 #' @title Geometrically weighted degree distribution for the second mode in a bipartite network
 #' @description Geometrically weighted degree distribution for the second mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model equal to the weighted
@@ -3234,7 +3234,7 @@ InitErgmTerm.gwb2degree<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...,
 
 ################################################################################
 
-#' @name gwb2dsp-ergmTerm
+#' @templateVar name gwb2dsp
 #' @title Geometrically weighted dyadwise shared partner distribution for dyads in the second bipartition
 #' @description Geometrically weighted dyadwise shared partner distribution for dyads in the second bipartition
 #' @details This term adds one network statistic to the model equal to the geometrically
@@ -3295,7 +3295,7 @@ InitErgmTerm.gwb2dsp<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...) {
 
 ################################################################################
 
-#' @name gwdegree-ergmTerm
+#' @templateVar name gwdegree
 #' @title Geometrically weighted degree distribution
 #' @description Geometrically weighted degree distribution
 #' @details This term adds one network statistic to the model equal to the weighted
@@ -3382,7 +3382,7 @@ InitErgmTerm.gwdegree<-function(nw, arglist, gw.cutoff=30, ..., version=packageV
 
 ################################################################################
 
-#' @name gwdsp-ergmTerm
+#' @templateVar name gwdsp
 #' @title Geometrically weighted dyadwise shared partner distribution
 #' @description Geometrically weighted dyadwise shared partner distribution
 #' @details This term adds one network statistic to the model equal to the geometrically
@@ -3451,7 +3451,7 @@ InitErgmTerm.gwdsp<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...) {
 
 ################################################################################
 
-#' @name gwesp-ergmTerm
+#' @templateVar name gwesp
 #' @title Geometrically weighted edgewise shared partner distribution
 #' @description Geometrically weighted edgewise shared partner distribution
 #' @details This term is just like `gwdsp` except it adds a statistic equal to the
@@ -3521,7 +3521,7 @@ InitErgmTerm.gwesp<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...) {
 
 ################################################################################
 
-#' @name gwidegree-ergmTerm
+#' @templateVar name gwidegree
 #' @title Geometrically weighted in-degree distribution
 #' @description Geometrically weighted in-degree distribution
 #' @details This term adds one network statistic to the model
@@ -3610,7 +3610,7 @@ InitErgmTerm.gwidegree<-function(nw, arglist, gw.cutoff=30, ..., version=package
 
 ################################################################################
 
-#' @name gwnsp-ergmTerm
+#' @templateVar name gwnsp
 #' @title Geometrically weighted nonedgewise shared partner distribution
 #' @description Geometrically weighted nonedgewise shared partner distribution
 #' @details This term is just like
@@ -3679,7 +3679,7 @@ InitErgmTerm.gwnsp<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...) {
 
 ################################################################################
 
-#' @name gwodegree-ergmTerm
+#' @templateVar name gwodegree
 #' @title Geometrically weighted out-degree distribution
 #' @description Geometrically weighted out-degree distribution
 #' @details This term adds one network statistic to the model
@@ -3772,7 +3772,7 @@ InitErgmTerm.gwodegree<-function(nw, arglist, gw.cutoff=30, ..., version=package
 
 ################################################################################
 
-#' @name hamming-ergmTerm
+#' @templateVar name hamming
 #' @title Hamming distance
 #' @description Hamming distance
 #' @details This term adds one statistic to the model equal to the weighted or
@@ -3987,7 +3987,7 @@ InitErgmTerm.hammingmix<-function (nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name idegrange-ergmTerm
+#' @templateVar name idegrange
 #' @title In-degree range
 #' @description In-degree range
 #' @details This term adds one
@@ -4096,7 +4096,7 @@ InitErgmTerm.idegrange<-function(nw, arglist, ..., version=packageVersion("ergm"
 
 ################################################################################
 
-#' @name idegree-ergmTerm
+#' @templateVar name idegree
 #' @title In-degree
 #' @description In-degree
 #' @details This term adds one network statistic to
@@ -4186,7 +4186,7 @@ InitErgmTerm.idegree<-function(nw, arglist, ..., version=packageVersion("ergm"))
 
 ################################################################################
 
-#' @name idegree1.5-ergmTerm
+#' @templateVar name idegree1.5
 #' @title In-degree to the 3/2 power
 #' @description In-degree to the 3/2 power
 #' @details This term adds one network statistic to the model equaling the sum
@@ -4229,7 +4229,7 @@ InitErgmTerm.idegreepopularity<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name intransitive-ergmTerm
+#' @templateVar name intransitive
 #' @title Intransitive triads
 #' @description Intransitive triads
 #' @details This term adds one statistic to the model, equal to the number of triads in
@@ -4260,7 +4260,7 @@ InitErgmTerm.intransitive<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name isolatededges-ergmTerm
+#' @templateVar name isolatededges
 #' @title Isolated edges
 #' @description Isolated edges
 #' @details This term adds one statistic to the
@@ -4294,7 +4294,7 @@ InitErgmTerm.isolatededges <- function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name isolates-ergmTerm
+#' @templateVar name isolates
 #' @title Isolates
 #' @description Isolates
 #' @details This term adds one statistic to the
@@ -4330,7 +4330,7 @@ InitErgmTerm.isolates <- function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name istar-ergmTerm
+#' @templateVar name istar
 #' @title In-stars
 #' @description In-stars
 #' @details This term adds one network statistic to the
@@ -4404,7 +4404,7 @@ InitErgmTerm.istar<-function(nw, arglist, ..., version=packageVersion("ergm")) {
 
 ################################################################################
 
-#' @name kstar-ergmTerm
+#' @templateVar name kstar
 #' @title k-Stars
 #' @description k-Stars
 #' @details This term adds one
@@ -4476,7 +4476,7 @@ InitErgmTerm.kstar<-function(nw, arglist, ..., version=packageVersion("ergm")) {
 
 ################################################################################
 
-#' @name localtriangle-ergmTerm
+#' @templateVar name localtriangle
 #' @title Triangles within neighborhoods
 #' @description Triangles within neighborhoods
 #' @details This term adds one statistic to the model equal to the number of triangles
@@ -4534,7 +4534,7 @@ InitErgmTerm.localtriangle<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name m2star-ergmTerm
+#' @templateVar name m2star
 #' @title Mixed 2-stars, a.k.a 2-paths
 #' @description Mixed 2-stars, a.k.a 2-paths
 #' @details This term adds one statistic to the model, equal to the number of mixed
@@ -4565,7 +4565,7 @@ InitErgmTerm.m2star<-function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name meandeg-ergmTerm
+#' @templateVar name meandeg
 #' @title Mean vertex degree
 #' @description Mean vertex degree
 #' @details This term adds one network statistic to the model equal to the
@@ -4592,7 +4592,7 @@ InitErgmTerm.meandeg<-function(nw, arglist, ...) {
 
 ################################################################################
 
-#' @name mm-ergmTerm
+#' @templateVar name mm
 #' @title Mixing matrix cells and margins
 #' @description Mixing matrix cells and margins
 #' @details `attrs` is the rows of the mixing matrix and whose RHS gives
@@ -4739,7 +4739,7 @@ InitErgmTerm.mm<-function (nw, arglist, ..., version=packageVersion("ergm")) {
 
 ################################################################################
 
-#' @name mutual-ergmTerm
+#' @templateVar name mutual
 #' @title Mutuality
 #' @description Mutuality
 #' @details In binary ERGMs, equal to the number of
@@ -4864,7 +4864,7 @@ InitErgmTerm.mutual<-function (nw, arglist, ..., version=packageVersion("ergm"))
 
 ################################################################################
 
-#' @name nearsimmelian-ergmTerm
+#' @templateVar name nearsimmelian
 #' @title Near simmelian triads
 #' @description Near simmelian triads
 #' @details This term adds one statistic to the model equal to the number of near
@@ -4892,7 +4892,7 @@ InitErgmTerm.nearsimmelian<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name nodecov-ergmTerm
+#' @templateVar name nodecov
 #' @title Main effect of a covariate
 #' @description Main effect of a covariate
 #' @details This term adds a single network statistic for each quantitative attribute or matrix column to the model equaling the sum of
@@ -4949,7 +4949,7 @@ InitErgmTerm.nodemain<-InitErgmTerm.nodecov
 
 ################################################################################
 
-#' @name nodefactor-ergmTerm
+#' @templateVar name nodefactor
 #' @title Factor attribute effect
 #' @description Factor attribute effect
 #' @details This term adds multiple network statistics to the
@@ -5025,7 +5025,7 @@ InitErgmTerm.nodefactor<-function (nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name nodeicov-ergmTerm
+#' @templateVar name nodeicov
 #' @title Main effect of a covariate for in-edges
 #' @description Main effect of a covariate for in-edges
 #' @details This term adds a single network statistic for each quantitative attribute or matrix column to the model equaling the total
@@ -5077,7 +5077,7 @@ InitErgmTerm.nodeicov<-function (nw, arglist, ..., version=packageVersion("ergm"
 
 ################################################################################
 
-#' @name nodeifactor-ergmTerm
+#' @templateVar name nodeifactor
 #' @title Factor attribute effect for in-edges
 #' @description Factor attribute effect for in-edges
 #' @details This term adds multiple network
@@ -5154,7 +5154,7 @@ InitErgmTerm.nodeifactor<-function (nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name nodematch-ergmTerm
+#' @templateVar name nodematch
 #' @title Uniform homophily and differential homophily
 #' @description Uniform homophily and differential homophily
 #' @details When `diff=FALSE` , this term adds one network statistic
@@ -5243,7 +5243,7 @@ InitErgmTerm.nodematch<-InitErgmTerm.match<-function (nw, arglist, ..., version=
 
 ################################################################################
 
-#' @name nodemix-ergmTerm
+#' @templateVar name nodemix
 #' @title Nodal attribute mixing
 #' @description Nodal attribute mixing
 #' @details By default, this term adds one network statistic to
@@ -5457,7 +5457,7 @@ InitErgmTerm.nodemix<-function (nw, arglist, ..., version=packageVersion("ergm")
 
 ################################################################################
 
-#' @name nodeocov-ergmTerm
+#' @templateVar name nodeocov
 #' @title Main effect of a covariate for out-edges
 #' @description Main effect of a covariate for out-edges
 #' @details This term adds a single network statistic for each quantitative attribute or matrix column to the model equaling the total
@@ -5509,7 +5509,7 @@ InitErgmTerm.nodeocov<-function (nw, arglist, ..., version=packageVersion("ergm"
 
 ################################################################################
 
-#' @name nodeofactor-ergmTerm
+#' @templateVar name nodeofactor
 #' @title Factor attribute effect for out-edges
 #' @description Factor attribute effect for out-edges
 #' @details This term adds multiple network
@@ -5586,7 +5586,7 @@ InitErgmTerm.nodeofactor<-function (nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name nsp-ergmTerm
+#' @templateVar name nsp
 #' @title Nonedgewise shared partners
 #' @description Nonedgewise shared partners
 #' @details This is
@@ -5650,7 +5650,7 @@ InitErgmTerm.nsp<-function(nw, arglist, cache.sp=TRUE, ...) {
 
 ################################################################################
 
-#' @name odegrange-ergmTerm
+#' @templateVar name odegrange
 #' @title Out-degree range
 #' @description Out-degree range
 #' @details This term adds one
@@ -5763,7 +5763,7 @@ InitErgmTerm.odegrange<-function(nw, arglist, ..., version=packageVersion("ergm"
 
 ################################################################################
 
-#' @name odegree-ergmTerm
+#' @templateVar name odegree
 #' @title Out-degree
 #' @description Out-degree
 #' @details This term adds one network statistic to
@@ -5854,7 +5854,7 @@ InitErgmTerm.odegree<-function(nw, arglist, ..., version=packageVersion("ergm"))
 
 ################################################################################
 
-#' @name odegree1.5-ergmTerm
+#' @templateVar name odegree1.5
 #' @title Out-degree to the 3/2 power
 #' @description Out-degree to the 3/2 power
 #' @details This term adds one network statistic to the model equaling the sum
@@ -5896,7 +5896,7 @@ InitErgmTerm.odegreepopularity<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name opentriad-ergmTerm
+#' @templateVar name opentriad
 #' @title Open triads
 #' @description Open triads
 #' @details This term
@@ -5923,7 +5923,7 @@ InitErgmTerm.opentriad<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name ostar-ergmTerm
+#' @templateVar name ostar
 #' @title k-Outstars
 #' @description k-Outstars
 #' @details This term adds one network statistic to the
@@ -6003,7 +6003,7 @@ InitErgmTerm.ostar<-function(nw, arglist, ..., version=packageVersion("ergm")) {
 
 ################################################################################
 
-#' @name receiver-ergmTerm
+#' @templateVar name receiver
 #' @title Receiver effect
 #' @description Receiver effect
 #' @details This term adds one network statistic for each node equal to the number of
@@ -6059,7 +6059,7 @@ InitErgmTerm.receiver<-function(nw, arglist, ..., version=packageVersion("ergm")
 
 ################################################################################
 
-#' @name sender-ergmTerm
+#' @templateVar name sender
 #' @title Sender effect
 #' @description Sender effect
 #' @details This term adds one network statistic for each node equal to the number of
@@ -6114,7 +6114,7 @@ InitErgmTerm.sender<-function(nw, arglist, ..., version=packageVersion("ergm")) 
 
 ################################################################################
 
-#' @name simmelian-ergmTerm
+#' @templateVar name simmelian
 #' @title Simmelian triads
 #' @description Simmelian triads
 #' @details This term adds one
@@ -6143,7 +6143,7 @@ InitErgmTerm.simmelian<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name simmelianties-ergmTerm
+#' @templateVar name simmelianties
 #' @title Ties in simmelian triads
 #' @description Ties in simmelian triads
 #' @details This term adds
@@ -6177,7 +6177,7 @@ InitErgmTerm.simmelianties<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name smalldiff-ergmTerm
+#' @templateVar name smalldiff
 #' @title Number of ties between actors with similar attribute values
 #' @description Number of ties between actors with similar (but not necessarily identical) attribute values
 #' @details This term adds one statistic, having as its
@@ -6234,7 +6234,7 @@ InitErgmTerm.smalldiff<-function (nw, arglist, ..., version=packageVersion("ergm
 
 ################################################################################
 
-#' @name sociality-ergmTerm
+#' @templateVar name sociality
 #' @title Undirected degree
 #' @description Undirected degree
 #' @details This term adds one network statistic for each node equal to the number of
@@ -6350,7 +6350,7 @@ InitErgmTerm.threepath <- function(nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name threetrail-ergmTerm
+#' @templateVar name threetrail
 #' @title Three-trails
 #' @description Three-trails
 #' @details For an undirected network, this term adds one statistic equal to the number
@@ -6428,7 +6428,7 @@ InitErgmTerm.threetrail <- function(nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name transitive-ergmTerm
+#' @templateVar name transitive
 #' @title Transitive triads
 #' @description Transitive triads
 #' @details This term adds one statistic to the model, equal to the number of triads in
@@ -6457,7 +6457,7 @@ InitErgmTerm.transitive<-function (nw, arglist, ...) {
 
 ################################################################################
 
-#' @name triadcensus-ergmTerm
+#' @templateVar name triadcensus
 #' @title Triad census
 #' @description Triad census
 #' @details For a directed network, this term adds one network statistic for each of
@@ -6550,7 +6550,7 @@ InitErgmTerm.triadcensus<-function (nw, arglist, ..., version=packageVersion("er
 
 ################################################################################
 
-#' @name triangle-ergmTerm
+#' @templateVar name triangle
 #' @title Triangles
 #' @description Triangles
 #' @details By default, this term adds one statistic to the model equal to the number of triangles
@@ -6626,7 +6626,7 @@ InitErgmTerm.triangle<-InitErgmTerm.triangles<-function (nw, arglist, ..., versi
 
 ################################################################################
 
-#' @name tripercent-ergmTerm
+#' @templateVar name tripercent
 #' @title Triangle percentage
 #' @description Triangle percentage
 #' @details By default, this term adds one statistic to the model equal to 100 times the ratio of
@@ -6700,7 +6700,7 @@ InitErgmTerm.tripercent<-function (nw, arglist, ..., version=packageVersion("erg
 
 ################################################################################
 
-#' @name ttriple-ergmTerm
+#' @templateVar name ttriple
 #' @title Transitive triples
 #' @description Transitive triples
 #' @details By default, this term adds one statistic to the model, equal to the number of transitive
@@ -6777,7 +6777,7 @@ InitErgmTerm.ttriad<-InitErgmTerm.ttriple
 
 ################################################################################
 
-#' @name twopath-ergmTerm
+#' @templateVar name twopath
 #' @title 2-Paths
 #' @description 2-Paths
 #' @details This term adds one statistic to the model, equal to the number of 2-paths in

--- a/R/InitErgmTerm.bipartite.R
+++ b/R/InitErgmTerm.bipartite.R
@@ -20,7 +20,7 @@
 
 #########################################################
 
-#' @name b1nodematch-ergmTerm
+#' @templateVar name b1nodematch
 #' @title Nodal attribute-based homophily effect for the first mode in a bipartite network
 #' @description Nodal attribute-based homophily effect for the first mode in a bipartite (aka two-mode) network
 #' @details This term is introduced
@@ -154,7 +154,7 @@ InitErgmTerm.b1nodematch	<-	function (nw, arglist, ..., version=packageVersion("
 
 ##########################################################
 
-#' @name b2nodematch-ergmTerm
+#' @templateVar name b2nodematch
 #' @title Nodal attribute-based homophily effect for the second mode in a bipartite network
 #' @description Nodal attribute-based homophily effect for the second mode in a bipartite (aka two-mode) network
 #' @details This term is introduced in Bomiriya et al (2014).

--- a/R/InitErgmTerm.bipartite.degree.R
+++ b/R/InitErgmTerm.bipartite.degree.R
@@ -16,7 +16,7 @@
 
 ###########  InitErgmTerm.b1mindegree  ###################
 
-#' @name b1mindegree-ergmTerm
+#' @templateVar name b1mindegree
 #' @title Minimum degree for the first mode in a bipartite network
 #' @description Minimum degree for the first mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model for
@@ -60,7 +60,7 @@ InitErgmTerm.b1mindegree <- function(nw, arglist, ...) {
 
 ###########  InitErgmTerm.b2mindegree  ###################
 
-#' @name b2mindegree-ergmTerm
+#' @templateVar name b2mindegree
 #' @title Minimum degree for the second mode in a bipartite network
 #' @description Minimum degree for the second mode in a bipartite (aka two-mode) network
 #' @details This term adds one network statistic to the model for

--- a/R/InitErgmTerm.blockop.R
+++ b/R/InitErgmTerm.blockop.R
@@ -10,7 +10,7 @@
 ## Creates a submodel that ignores any edges not within the
 ## blocks.
 
-#' @name NodematchFilter-ergmTerm
+#' @templateVar name NodematchFilter
 #' @title Filtering on nodematch
 #' @description Filtering on nodematch
 #' @details Evaluates the terms specified in `formula` on a network

--- a/R/InitErgmTerm.coincidence.R
+++ b/R/InitErgmTerm.coincidence.R
@@ -8,7 +8,7 @@
 #  Copyright 2003-2021 Statnet Commons
 #######################################################################
 
-#' @name coincidence-ergmTerm
+#' @templateVar name coincidence
 #' @title Coincident node count for the second mode in a bipartite (aka two-mode) network
 #' @description Coincident node count for the second mode in a bipartite (aka two-mode) network
 #' @details By default this term adds one

--- a/R/InitErgmTerm.dgw_sp.R
+++ b/R/InitErgmTerm.dgw_sp.R
@@ -137,7 +137,7 @@
 #routine is used (since it is safe for undirected graphs), irrespective of
 #the user's selection.  UTP cannot be chosen otherwise, since it won't work.
 
-#' @name desp-ergmTerm
+#' @templateVar name desp
 #' @title Directed edgewise shared partners
 #' @description Directed edgewise shared partners
 #' @details This term adds one network statistic to the model for each element in `d` where the \eqn{i} th such statistic equals the number of edges in the network with exactly `d[i]` shared partners.
@@ -204,7 +204,7 @@ InitErgmTerm.desp<-function(nw, arglist, cache.sp=TRUE, ...) {
 #always used (since it is directedness-safe), and the user's input is
 #overridden.  UTP cannot be chosen otherwise, since it won't work.
 
-#' @name dgwesp-ergmTerm
+#' @templateVar name dgwesp
 #' @title Geometrically weighted edgewise shared partner distribution
 #' @description Geometrically weighted edgewise shared partner distribution
 #' @details This term adds a statistic equal to the geometrically weighted edgewise (not dyadwise) shared partner distribution with decay parameter `decay` parameter.
@@ -301,7 +301,7 @@ InitErgmTerm.dgwesp<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...) {
 #the user's selection.  UTP cannot be chosen otherwise, since it won't work.
 #
 
-#' @name ddsp-ergmTerm
+#' @templateVar name ddsp
 #' @title Directed dyadwise shared partners
 #' @description Directed dyadwise shared partners
 #' @details This term adds one network statistic to the model for each element in `d` where the \eqn{i} th such statistic equals the number of dyads in the network with exactly `d[i]` shared partners.
@@ -364,7 +364,7 @@ InitErgmTerm.ddsp<-function(nw, arglist, cache.sp=TRUE, ...) {
 
 ################################################################################
 
-#' @name dgwdsp-ergmTerm
+#' @templateVar name dgwdsp
 #' @title Geometrically weighted dyadwise shared partner distribution
 #' @description Geometrically weighted dyadwise shared partner distribution
 #' @details This term adds one network statistic to the model equal to the geometrically weighted dyadwise shared partner distribution with decay parameter `decay` parameter.
@@ -467,7 +467,7 @@ InitErgmTerm.dgwdsp<-function(nw, arglist, cache.sp=TRUE, gw.cutoff=30, ...) {
 #the user's selection.  UTP cannot be chosen otherwise, since it won't work.
 #
 
-#' @name dnsp-ergmTerm
+#' @templateVar name dnsp
 #' @title Directed non-edgewise shared partners
 #' @description Directed non-edgewise shared partners
 #' @details This term adds one network statistic to the model for each element in `d` where the \eqn{i} th such statistic equals the number of non-edges in the network with exactly `d[i]` shared partners.
@@ -529,7 +529,7 @@ InitErgmTerm.dnsp<-function(nw, arglist, cache.sp=TRUE, ...) {
 
 ################################################################################
 
-#' @name dgwnsp-ergmTerm
+#' @templateVar name dgwnsp
 #' @title Geometrically weighted non-edgewise shared partner distribution
 #' @description Geometrically weighted non-edgewise shared partner distribution
 #' @details This term is just like gwesp and gwdsp except it adds a statistic equal to the geometrically weighted nonedgewise (that is, over dyads that do not have an edge) shared partner distribution with decay parameter `decay` parameter.

--- a/R/InitErgmTerm.extra.R
+++ b/R/InitErgmTerm.extra.R
@@ -11,7 +11,7 @@
 #NOTE: a number of undocumented terms have been removed from this file
 # the terms still exist on the experimental_terms svn branch
 
-#' @name concurrentties-ergmTerm
+#' @templateVar name concurrentties
 #' @title Concurrent tie count
 #' @description Concurrent tie count
 #' @details This term adds one network statistic to the model, equal to the number of

--- a/R/InitErgmTerm.operator.R
+++ b/R/InitErgmTerm.operator.R
@@ -147,7 +147,7 @@ InitErgmTerm.Passthrough <- function(nw, arglist, ...){
     wrap.ergm_model(m, nw, if(a$label) ergm_mk_std_op_namewrap('Passthrough') else identity))
 }
 
-#' @name Label-ergmTerm
+#' @templateVar name Label
 #' @title Modify terms' coefficient names
 #' @description Modify terms' coefficient names
 #' @details This operator evaluates `formula` without modification, but modifies its coefficient and/or parameter names based on `label` and `pos` .
@@ -288,7 +288,10 @@ InitErgmTerm..submodel_and_summary <- function(nw, arglist, ...){
     wrap.ergm_model(m, nw, NULL))
 }
 
+# Roxygen converts the name to FALSE-ergmTerm if the name is not specified. This generates a warning but is probably the best we can do
+
 #' @name F-ergmTerm
+#' @templateVar name F
 #' @title Filtering on arbitrary one-term model.
 #' @description Filtering on arbitrary one-term model.
 #' @details Evaluates the given `formula` on a network constructed by
@@ -364,7 +367,7 @@ InitErgmTerm..filter.formula.net <- function(nw, arglist, ...){
     wrap.ergm_model(m, nw, NULL))
 }
 
-#' @name Offset-ergmTerm
+#' @templateVar name Offset
 #' @title Terms with fixed coefficients
 #' @description Terms with fixed coefficients
 #' @details This operator is analogous to the `offset()` wrapper, but the
@@ -574,7 +577,7 @@ ergm_symmetrize.network <- function(x, rule=c("weak","strong","upper","lower"), 
   nvattr.copy.network(o, x)
 }
 
-#' @name Symmetrize-ergmTerm
+#' @templateVar name Symmetrize
 #' @title Evaluation on symmetrized (undirected) network
 #' @description Evaluation on symmetrized (undirected) network
 #' @details :
@@ -625,7 +628,7 @@ InitErgmTerm.Symmetrize <- function(nw, arglist, ...){
                list(dependence=!is.dyad.independent(m) || rule%in%c("weak","strong"))))
 }
 
-#' @name Sum-operator-ergmTerm
+#' @templateVar name Sum-operator
 #' @title A sum (or an arbitrary linear combination) of one or more formulas
 #' @description A sum (or an arbitrary linear combination) of one or more formulas
 #' @details This operator sums up the RHS statistics of the input formulas elementwise.
@@ -766,7 +769,7 @@ InitErgmTerm.Sum <- function(nw, arglist,...){
     wms[[1L]][c("map", "gradient", "params", "minpar", "maxpar")])
 }
 
-#' @name S-ergmTerm
+#' @templateVar name S
 #' @title Evaluation on an induced subgraph
 #' @description Evaluation on an induced subgraph
 #' @details This operator takes a two-sided forumla `attrs` whose LHS gives the attribute or attribute function for which tails and heads will be used to construct the induced subgraph. They must evaluate either to a logical vector equal in length to the number of tails (for LHS) and heads (for RHS) indicating which nodes are to be used to induce the subgraph or a numeric vector giving their indices. (As with indexing vectors, the logical vector will be recycled to the size of the network or the size of the appropriate bipartition, and negative indices will deselect vertices.)
@@ -852,7 +855,7 @@ InitErgmTerm.S <- function(nw, arglist, ...){
 }
 
 
-#' @name Curve-ergmTerm
+#' @templateVar name Curve
 #' @title Impose a curved structure on term parameters.
 #' @description Impose a curved structure on term parameters.
 #' @details Arguments may have the same forms as in the API, but for convenience, alternative forms are accepted.
@@ -973,7 +976,7 @@ InitErgmTerm.Parametrise <- InitErgmTerm.Curve
 #' #           cov=NULL)
 InitErgmTerm.Parametrize <- InitErgmTerm.Curve
 
-#' @name Log-ergmTerm
+#' @templateVar name Log
 #' @title Take a natural logarithm of a network's statistic
 #' @description Take a natural logarithm of a network's statistic
 #' @details Evaluate the terms specified in `formula` and takes a natural (base \eqn{e} ) logarithm of them. Since an ERGM statistic must be finite, `log0` specifies the value to be substituted for `log(0)` . The default value seems reasonable for most purposes.
@@ -1004,7 +1007,7 @@ InitErgmTerm.Log <- function(nw, arglist, ...){
   c(list(name="Log", inputs=log0, auxiliaries=~.submodel_and_summary(m)), wm)
 }
 
-#' @name Exp-ergmTerm
+#' @templateVar name Exp
 #' @title Exponentiate a network's statistic
 #' @description Exponentiate a network's statistic
 #' @details Evaluate the terms specified in `formula` and exponentiates them with base \eqn{e} .
@@ -1032,7 +1035,7 @@ InitErgmTerm.Exp <- function(nw, arglist, ...){
   c(list(name="Exp", auxiliaries=~.submodel_and_summary(m)), wm)
 }
 
-#' @name Prod-ergmTerm
+#' @templateVar name Prod
 #' @title A product (or an arbitrary power combination) of one or more formulas
 #' @description A product (or an arbitrary power combination) of one or more formulas
 #' @details This operator evaluates a list of formulas whose corresponnding RHS

--- a/R/InitErgmTerm.transitiveties.R
+++ b/R/InitErgmTerm.transitiveties.R
@@ -11,7 +11,7 @@
 
 #################################################################################
 
-#' @name transitiveties-ergmTerm
+#' @templateVar name transitiveties
 #' @title Transitive ties
 #' @description Transitive ties
 #' @details This term adds one statistic, equal to the number of ties
@@ -79,7 +79,7 @@ InitErgmTerm.transitiveties<-function (nw, arglist, ..., version=packageVersion(
 
 #################################################################################
 
-#' @name cyclicalties-ergmTerm
+#' @templateVar name cyclicalties
 #' @title Cyclical ties
 #' @description Cyclical ties
 #' @details This term adds one statistic, equal to the number of ties

--- a/R/InitWtErgmTerm.R
+++ b/R/InitWtErgmTerm.R
@@ -79,7 +79,7 @@ InitWtErgmTerm.absdiffcat <- function(nw, arglist, ..., version=packageVersion("
 }
 
 
-#' @name atleast-ergmTerm
+#' @templateVar name atleast
 #' @title Number of dyads with values greater than or equal to a threshold
 #' @description Number of dyads with values greater than or equal to a threshold
 #' @details Adds the number of
@@ -112,7 +112,7 @@ InitWtErgmTerm.atleast<-function(nw, arglist, ...) {
        emptynwstats=ifelse(0>=a$threshold, network.dyadcount(nw,FALSE), 0))
 }
 
-#' @name atmost-ergmTerm
+#' @templateVar name atmost
 #' @title Number of dyads with values less than or equal to a threshold
 #' @description Number of dyads with values less than or equal to a threshold
 #' @details Adds the number of
@@ -297,7 +297,7 @@ InitWtErgmTerm.edgecov <- function(nw, arglist, ...) {
   binary_dind_wrap("edgecov", nw, a, ...)
 }
 
-#' @name equalto-ergmTerm
+#' @templateVar name equalto
 #' @title Number of dyads with values equal to a specific value
 #' @description Number of dyads with values equal to a specific value (within tolerance)
 #' @details Adds one statistic equal to the number of dyads whose values
@@ -328,7 +328,7 @@ InitWtErgmTerm.equalto<-function(nw, arglist, ...) {
        emptynwstats=if(abs(a$value)<=a$tolerance) network.dyadcount(nw,FALSE) else 0)
 }
 
-#' @name ininterval-ergmTerm
+#' @templateVar name ininterval
 #' @title Number of dyads whose values are in an interval
 #' @description Number of dyads whose values are in an interval
 #' @details Adds one statistic equaling to the number of dyads whose values
@@ -379,7 +379,7 @@ InitWtErgmTerm.ininterval<-function(nw, arglist, ...) {
        ) network.dyadcount(nw,FALSE) else 0)
 }
 
-#' @name greaterthan-ergmTerm
+#' @templateVar name greaterthan
 #' @title Number of dyads with values strictly greater than a threshold
 #' @description Number of dyads with values strictly greater than a threshold
 #' @details Adds the number of
@@ -410,7 +410,7 @@ InitWtErgmTerm.greaterthan<-function(nw, arglist, ...) {
        emptynwstats=ifelse(0>a$threshold, network.dyadcount(nw,FALSE), 0))
 }
 
-#' @name smallerthan-ergmTerm
+#' @templateVar name smallerthan
 #' @title Number of dyads with values strictly smaller than a threshold
 #' @description Number of dyads with values strictly smaller than a threshold
 #' @details Adds the number of
@@ -442,7 +442,7 @@ InitWtErgmTerm.smallerthan<-function(nw, arglist, ...) {
 }
 
 
-#' @name sum-ergmTerm
+#' @templateVar name sum
 #' @title Sum of dyad values (optionally taken to a power)
 #' @description Sum of dyad values (optionally taken to a power)
 #' @details This term adds one statistic equal to the sum of
@@ -477,7 +477,7 @@ InitWtErgmTerm.sum<-function(nw, arglist, ...) {
 }
 
 
-#' @name nodecovar-ergmTerm
+#' @templateVar name nodecovar
 #' @title Covariance of undirected dyad values incident on each actor
 #' @description Covariance of undirected dyad values incident on each actor
 #' @details This term adds one statistic equal to
@@ -591,7 +591,7 @@ InitWtErgmTerm.sociality<-function (nw, arglist, ..., version=packageVersion("er
 }
 
 
-#' @name nodeocovar-ergmTerm
+#' @templateVar name nodeocovar
 #' @title Covariance of out-dyad values incident on each actor
 #' @description Covariance of out-dyad values incident on each actor
 #' @details This term adds one statistic equal to
@@ -681,7 +681,7 @@ InitWtErgmTerm.sender<-function (nw, arglist, ..., version=packageVersion("ergm"
   binary_dind_wrap("sender", nw, a, ..., version=version)
 }
 
-#' @name nodeicovar-ergmTerm
+#' @templateVar name nodeicovar
 #' @title Covariance of in-dyad values incident on each actor
 #' @description Covariance of in-dyad values incident on each actor
 #' @details This term adds one statistic equal to
@@ -959,7 +959,7 @@ InitWtErgmTerm.transitiveties<-function (nw, arglist, ...) {
        minval=0, maxval=network.dyadcount(nw,FALSE))  
 }
 
-#' @name transitiveweights-ergmTerm
+#' @templateVar name transitiveweights
 #' @title Transitive weights
 #' @description Transitive weights
 #' @details This statistic implements the transitive weights
@@ -1031,7 +1031,7 @@ InitWtErgmTerm.cyclicalties<-function (nw, arglist, ...) {
   
 }
 
-#' @name cyclicalweights-ergmTerm
+#' @templateVar name cyclicalweights
 #' @title Cyclical weights
 #' @description Cyclical weights
 #' @details This statistic implements the cyclical weights

--- a/R/InitWtErgmTerm.operator.R
+++ b/R/InitWtErgmTerm.operator.R
@@ -13,7 +13,7 @@ InitWtErgmTerm.Passthrough <- function(nw, arglist, ...){
   out
 }
 
-#' @name B-ergmTerm
+#' @templateVar name B
 #' @title Wrap binary terms for use in valued models
 #' @description Wrap binary terms for use in valued models
 #' @details Wraps binary `ergm` terms for use in valued models, with `formula` specifying which terms

--- a/man-roxygen/ergmConstraint-general.R
+++ b/man-roxygen/ergmConstraint-general.R
@@ -1,1 +1,2 @@
+#' @name <%= name %>-ergmConstraint
 #' @seealso [`ergmConstraint`] for index of constraints and hints currently visible to the package.

--- a/man-roxygen/ergmHint-general.R
+++ b/man-roxygen/ergmHint-general.R
@@ -1,2 +1,3 @@
 #' @name <%= name %>-ergmHint
+#' @aliases <%= name %>-ergmConstraint
 #' @seealso [`ergmHint`] for index of constraints and hints currently visible to the package.

--- a/man-roxygen/ergmHint-general.R
+++ b/man-roxygen/ergmHint-general.R
@@ -1,1 +1,2 @@
+#' @name <%= name %>-ergmHint
 #' @seealso [`ergmHint`] for index of constraints and hints currently visible to the package.

--- a/man-roxygen/ergmReference-general.R
+++ b/man-roxygen/ergmReference-general.R
@@ -1,1 +1,2 @@
+#' @name <%= name %>-ergmReference
 #' @seealso [`ergmReference`] for index of reference distributions currently visible to the package.

--- a/man-roxygen/ergmTerm-general.R
+++ b/man-roxygen/ergmTerm-general.R
@@ -1,1 +1,2 @@
+#' @name <%= name %>-ergmTerm
 #' @seealso [`ergmTerm`] for index of model terms currently visible to the package.

--- a/man/sparse-ergmHint.Rd
+++ b/man/sparse-ergmHint.Rd
@@ -12,6 +12,6 @@
 The network is sparse. This typically results in a Tie-Non-Tie (TNT) proposal regime.
 }
 \seealso{
-\code{\link{ergmConstraint}} for index of constraints and hints currently visible to the package.
+\code{\link{ergmHint}} for index of constraints and hints currently visible to the package.
 }
 \concept{dyad-independent}


### PR DESCRIPTION
Moved the termalike documentation name to the type specific general templates. (statnet/ergm#406)

Aliased *-ergmHint entries to the corresponding *-ergmConstraint. (statnet/ergm#404)