### PR TITLE
a simple optimization to ergm.godfather

### DIFF
--- a/R/godfather.R
+++ b/R/godfather.R
@@ -88,17 +88,18 @@ ergm.godfather <- function(formula, changes=NULL, response=NULL,
   ncols <- sapply(changes, ncol)
   if(!all_identical(ncols) || ncols[1]<2 || ncols[1]>3 || (is.valued(nw)&&ncols[1]==2)) abort("Invalid format for list of changes. See help('ergm.godfather').")
 
-  if(!is.directed(nw)) changes <- lapply(changes, function(x){
-    x[,1:2] <- t(apply(x[,1:2,drop=FALSE], 1, sort))
-    x
-  })
-
   m <- ergm_model(formula, nw, term.options=control$term.options)
   state <- ergm_state(nw, model=m)
   state <- update(state, stats = if(changes.only) numeric(nparam(state,canonical=TRUE)) else summary(state))
 
   changem <- changes %>% map(~rbind(0L,.)) %>% do.call(rbind, .) # 0s are sentinels indicating next iteration.
   if(!stats.start) changem <- changem[-1,,drop=FALSE] # I.e., overwrite the initial statistic rather than advancing past it first thing.
+  if(!is.directed(nw)) {
+    tails <- changem[,1]
+    heads <- changem[,2]
+    changem[,1] <- pmin(tails, heads)
+    changem[,2] <- pmax(tails, heads)
+  }
   
   if(verbose) message_print("Applying changes...\n")
   z <-


### PR DESCRIPTION
analogous to statnet/tergm#93

```
require(tergm)
nw <- network.initialize(1000, dir = F)
logit <- function(p) log(p/(1-p))
D <- 10
density <- 1/500
s <- simulate(nw ~ Form(~edges) + Persist(~edges),
              coef = c(logit(density) - log(D), log(D - 1)),
              output = "changes",
              time.slices = 1000,
              dynamic = TRUE)
              
toggles <- s[,-c(1,4),drop=FALSE]
              
toggles <- lapply(seq_len(NROW(toggles)), function(x) toggles[x,,drop=FALSE])
              
st <- Sys.time()
egf <- ergm.godfather(nw ~ edges,
                      changes = toggles)
et <- Sys.time()
print(et - st)
```

gives

```
Time difference of 14.95135 secs
```

with `master`, and

```
Time difference of 1.267468 secs
```

with this PR.