### PR TITLE
Covariance Methods for MPLE IV

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Authors@R: c(
              person("Chad", "Klumb", role=c("ctb"), email="cklumb@gmail.com"),
              person("Michał", " Bojanowski", role=c("ctb"), email="michal2992@gmail.com", comment=c(ORCID="0000-0001-7503-852X")),
              person("Ben", "Bolker", role=c("ctb"), email="bbolker+lme4@gmail.com"),
-             person("Christian", "Schmid", role=c("ctb"), email="cxs5700@psu.edu"),
+             person("Christian", "Schmid", role=c("ctb"), email="songhyo86@gmail.com"),
              person("Joyce", "Cheng", role=c("ctb"), email="joyce.cheng@student.unsw.edu.au"))
 Depends:
     R (>= 4.1),
@@ -147,6 +147,7 @@ Collate:
     'ergm_keyword.R'
     'ergm_model.R'
     'ergm_model.utils.R'
+    'ergm_mplecov.R'
     'ergm_proposal.R'
     'ergm_response.R'
     'ergm_state.R'

--- a/R/control.ergm.R
+++ b/R/control.ergm.R
@@ -119,22 +119,19 @@
 #'   similar diagnostic for the unconstrained MCMC sample's estimating
 #'   functions.
 #'
-#' @param MPLE.covariance.samplesize The number of networks to simulate to approximate
-#'  the MPLE covariance matrix using the Godambe matrix (see Schmid and Hunter (2020)) or
-#'  parametric Bootstrapping (see Schmid and Desmarais (2017)).
-#'
-#' @param MPLE.covariance.method The method to estimate the MPLE covariance method. `invHess`
-#'  returns the covariance estimate obtained from the glm()-function. `Godambe` estimates the
-#'  covariance matrix using the Godambe-matrix (Schmid and Hunter (2020)). This method is recommended
-#'  for dyad-dependent models. Alternatively, `bootstrap` estimates standard deviations using a parametric
-#'  bootstrapping approach (see Schmid and Desmarais (2017)).
-#'
-#' @param MPLE.covariance.sim.burnin Number of proposals before any MCMC sampling is done to simulate
-#'   networks for the MPLE covariance methods "Godambe" and "bootstrap".
-#'
-#' @param MPLE.covariance.sim.interval Number of proposals between simulated networks for the MPLE covariance
-#'   methods "Godambe" and "bootstrap".
-#'
+#' @param
+#'   MPLE.covariance.method,MPLE.covariance.samplesize,MPLE.covariance.sim.burnin,MPLE.covariance.sim.interval
+#'   Controls for estimating the MPLE covariance
+#'   matrix. `MPLE.covariance method` determines the method, with
+#'   `invHess` (the default) returning the covariance estimate
+#'   obtained from the [glm()]. `Godambe` estimates the covariance
+#'   matrix using the Godambe-matrix \insertCite{ScHu23c}{ergm}. This
+#'   method is recommended for dyad-dependent models. Alternatively,
+#'   `bootstrap` estimates standard deviations using a parametric
+#'   bootstrapping approach \insertCite{@see @ScDe17e}{ergm}. The
+#'   other parameters control, respectively, the number of networks to
+#'   simulate, the MCMC burn-in, and the MCMC interval for `Godambe`
+#'   and `bootstrap` methods.
 #'
 #' @param MPLE.constraints.ignore If `TRUE`, MPLE will ignore all
 #'   dyad-independent constraints except for those due to attributes
@@ -448,7 +445,8 @@
 #' @seealso [ergm()]. The \code{\link{control.simulate}} function
 #' performs a similar function for \code{\link{simulate.ergm}};
 #' \code{\link{control.gof}} performs a similar function for \code{\link{gof}}.
-#' @references \itemize{ 
+#' @references \insertAllCited{}
+#'
 #' * Snijders, T.A.B. (2002), Markov Chain Monte
 #' Carlo Estimation of Exponential Random Graph Models.  Journal of Social
 #' Structure.  Available from
@@ -472,8 +470,7 @@
 #' * Kristoffer Sahlin. Estimating convergence of Markov chain Monte Carlo
 #' simulations. Master's Thesis. Stockholm University, 2011.
 #' \url{https://www2.math.su.se/matstat/reports/master/2011/rep2/report.pdf}
-#' 
-#' }
+#'
 #' @keywords models
 #' @export control.ergm
 control.ergm<-function(drop=TRUE,

--- a/R/control.ergm.R
+++ b/R/control.ergm.R
@@ -119,6 +119,23 @@
 #'   similar diagnostic for the unconstrained MCMC sample's estimating
 #'   functions.
 #'
+#' @param MPLE.covariance.samplesize The number of networks to simulate to approximate
+#'  the MPLE covariance matrix using the Godambe matrix (see Schmid and Hunter (2020)) or
+#'  parametric Bootstrapping (see Schmid and Desmarais (2017)).
+#'
+#' @param MPLE.covariance.method The method to estimate the MPLE covariance method. `invHess`
+#'  returns the covariance estimate obtained from the glm()-function. `Godambe` estimates the
+#'  covariance matrix using the Godambe-matrix (Schmid and Hunter (2020)). This method is recommended
+#'  for dyad-dependent models. Alternatively, `bootstrap` estimates standard deviations using a parametric
+#'  bootstrapping approach (see Schmid and Desmarais (2017)).
+#'
+#' @param MPLE.covariance.sim.burnin Number of proposals before any MCMC sampling is done to simulate
+#'   networks for the MPLE covariance methods "Godambe" and "bootstrap".
+#'
+#' @param MPLE.covariance.sim.interval Number of proposals between simulated networks for the MPLE covariance
+#'   methods "Godambe" and "bootstrap".
+#'
+#'
 #' @param MPLE.constraints.ignore If `TRUE`, MPLE will ignore all
 #'   dyad-independent constraints except for those due to attributes
 #'   missingness. This can be used to avert evaluating and storing the
@@ -478,6 +495,10 @@ control.ergm<-function(drop=TRUE,
                        MPLE.nonvar=c("warning","message","error"),
                        MPLE.nonident=c("warning","message","error"),
                        MPLE.nonident.tol=1e-10,
+                       MPLE.covariance.samplesize =500,
+                       MPLE.covariance.method ="invHess",
+                       MPLE.covariance.sim.burnin = 1024,
+                       MPLE.covariance.sim.interval = 1024,
                        MPLE.constraints.ignore=FALSE,
 
                        MCMC.prop=trim_env(~sparse),

--- a/R/ergm.R
+++ b/R/ergm.R
@@ -618,7 +618,7 @@ ergm <- function(formula, response=NULL,
   }
   
   ## Run the fit.
-  fit <- ergm.fit(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, ...)
+  fit <- ergm.fit(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, formula, ...)
 
   ## Process MCMC sample results.
   if(control$MCMC.return.stats == 0) fit$sample <- fit$sample.obs <- NULL
@@ -682,7 +682,7 @@ ergm <- function(formula, response=NULL,
   fit
 }
 
-ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, ...){
+ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, formula,  ...){
   ## Short-circuit the optimization if all terms are either offsets or dropped.
   if(all(model$etamap$offsettheta)){
     ## Note that this cannot be overridden with control$force.main.
@@ -734,10 +734,12 @@ ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, cont
   ergm.getCluster(control, max(verbose-1,0)) # Set up parallel processing if necessary.
   
   initialfit <- ergm.initialfit(init=control$init,
-                                  s=s, s.obs=s.obs,
-                                  control=control,
-                                  verbose=max(verbose-1,0),
-                                  ...)
+                                s=s, s.obs=s.obs, nw = nw,
+                                control=control,
+                                constraints = constraints,
+                                verbose=max(verbose-1,0),
+                                formula = formula,
+                                ...)
 
   ## Extract and process the initial value for the next stage:
   init <- coef(initialfit)
@@ -746,10 +748,10 @@ ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, cont
 
   c(
     switch(control$main.method,
-           "MPLE" = ergm.mple(s, s.obs,
+           "MPLE" = ergm.mple(s, s.obs,nw,
                               init=init,
                               control=control,
-                              verbose=verbose, ...),
+                              verbose=verbose, formula = formula, ...),
 
            "CD" = ergm.CD.fixed(.constrain_init(s$model, ifelse(is.na(init),0,init)),
                       s, s.obs, control, verbose,...),

--- a/R/ergm.R
+++ b/R/ergm.R
@@ -618,7 +618,7 @@ ergm <- function(formula, response=NULL,
   }
   
   ## Run the fit.
-  fit <- ergm.fit(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, formula, ...)
+  fit <- ergm.fit(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, ...)
 
   ## Process MCMC sample results.
   if(control$MCMC.return.stats == 0) fit$sample <- fit$sample.obs <- NULL
@@ -682,7 +682,7 @@ ergm <- function(formula, response=NULL,
   fit
 }
 
-ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, formula,  ...){
+ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, control, verbose, ...){
   ## Short-circuit the optimization if all terms are either offsets or dropped.
   if(all(model$etamap$offsettheta)){
     ## Note that this cannot be overridden with control$force.main.
@@ -734,11 +734,9 @@ ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, cont
   ergm.getCluster(control, max(verbose-1,0)) # Set up parallel processing if necessary.
   
   initialfit <- ergm.initialfit(init=control$init,
-                                s=s, s.obs=s.obs, nw = nw,
+                                s=s, s.obs=s.obs,
                                 control=control,
-                                constraints = constraints,
                                 verbose=max(verbose-1,0),
-                                formula = formula,
                                 ...)
 
   ## Extract and process the initial value for the next stage:
@@ -748,10 +746,10 @@ ergm.fit <- function(nw, target.stats, model, proposal, proposal.obs, info, cont
 
   c(
     switch(control$main.method,
-           "MPLE" = ergm.mple(s, s.obs,nw,
+           "MPLE" = ergm.mple(s, s.obs,
                               init=init,
                               control=control,
-                              verbose=verbose, formula = formula, ...),
+                              verbose=verbose, ...),
 
            "CD" = ergm.CD.fixed(.constrain_init(s$model, ifelse(is.na(init),0,init)),
                       s, s.obs, control, verbose,...),

--- a/R/ergm.initialfit.R
+++ b/R/ergm.initialfit.R
@@ -48,9 +48,10 @@
 #
 ######################################################################################
 ergm.initialfit<-function(init,
-                          s, s.obs,
+                          s, s.obs, nw,
                           control=NULL,
-                          verbose=FALSE, ...) {
+                          constraints = NULL,
+                          verbose=FALSE, formula = formula, ...) {
   if(control$init.method!="skip" && any(is.na(init))){
     # Respect init elements that are not offsets if it's only a starting value.
     s$model$etamap$offsettheta[!is.na(init)] <- TRUE
@@ -60,16 +61,17 @@ ergm.initialfit<-function(init,
            MPLE = {
              if(control$MPLE.constraints.ignore) s$proposal$arguments$constraints <- s$proposal$arguments$constraints[".attributes"] # Drop all constraints except for .attributes .
              control$MPLE.samplesize <- control$init.MPLE.samplesize
-             ergm.mple(s, s.obs,
+             ergm.mple(s, s.obs, nw=nw,
                        init=init,
                        control=control,
-                       verbose=verbose, ...)
+                       constraints=constraints,
+                       verbose=verbose, formula = formula, ...)
            },
            zeros = structure(list(coefficients=.constrain_init(s$model, ifelse(is.na(init),0,init)))),
            CD = ergm.CD.fixed(.constrain_init(s$model, ifelse(is.na(init),0,init)),
                               s, s.obs, control, verbose, ...),
            stop("Invalid method specified for initial parameter calculation.")
-           )
+    )
   }else{
     # If this is just the initial value, *and* the user has supplied
     # all elements for init, just echo init.

--- a/R/ergm.initialfit.R
+++ b/R/ergm.initialfit.R
@@ -48,10 +48,9 @@
 #
 ######################################################################################
 ergm.initialfit<-function(init,
-                          s, s.obs, nw,
+                          s, s.obs,
                           control=NULL,
-                          constraints = NULL,
-                          verbose=FALSE, formula = formula, ...) {
+                          verbose=FALSE, ...) {
   if(control$init.method!="skip" && any(is.na(init))){
     # Respect init elements that are not offsets if it's only a starting value.
     s$model$etamap$offsettheta[!is.na(init)] <- TRUE
@@ -61,11 +60,10 @@ ergm.initialfit<-function(init,
            MPLE = {
              if(control$MPLE.constraints.ignore) s$proposal$arguments$constraints <- s$proposal$arguments$constraints[".attributes"] # Drop all constraints except for .attributes .
              control$MPLE.samplesize <- control$init.MPLE.samplesize
-             ergm.mple(s, s.obs, nw=nw,
+             ergm.mple(s, s.obs,
                        init=init,
                        control=control,
-                       constraints=constraints,
-                       verbose=verbose, formula = formula, ...)
+                       verbose=verbose, ...)
            },
            zeros = structure(list(coefficients=.constrain_init(s$model, ifelse(is.na(init),0,init)))),
            CD = ergm.CD.fixed(.constrain_init(s$model, ifelse(is.na(init),0,init)),

--- a/R/ergm.mple.R
+++ b/R/ergm.mple.R
@@ -37,7 +37,7 @@
 #' starting points for the MCMC algorithm.
 #' 
 #' @param state,state.obs [`ergm_state`] objects.
-#' @param init a vector a vector of initial theta coefficients
+#' @param init a vector of initial theta coefficients
 #' @param family the family to use in the R native routine
 #'   \code{\link{glm}}; only applicable if "glm" is the 'MPLEtype';
 #'   default="binomial"
@@ -45,6 +45,11 @@
 #' @templateVar mycontrol control.ergm
 #' @template control
 #' @template verbose
+#'
+#' @param constraints {A formula specifying one or more constraints
+#' on the support of the distribution of the networks being modeled,
+#' using syntax similar to the \code{formula} argument, on the
+#' right-hand side.
 #'
 #' @param \dots additional parameters passed from within; all will be
 #'   ignored
@@ -55,10 +60,12 @@
 #' @seealso \code{\link{ergmMPLE}},
 #' \code{\link{ergm}},\code{\link{control.ergm}}
 #' @references \insertAllCited{}
-ergm.mple<-function(s, s.obs, init=NULL,
+ergm.mple<-function(s, s.obs, nw, init=NULL,
                     family="binomial",
                     control=NULL,
+                    constraints=NULL,
                     verbose=FALSE,
+                    formula = formula,
                     ...) {
   m <- s$model
   message("Starting maximum pseudolikelihood estimation (MPLE):")
@@ -100,6 +107,16 @@ ergm.mple<-function(s, s.obs, init=NULL,
     glm.result <- .catchToList(glm(pl$zy ~ .-1 + offset(pl$foffset), 
                                   data=data.frame(pl$xmat),
                                   weights=pl$wend, family=family))
+
+   # estimate variability matrix V for Godambe covariance matrix or via bootstrapping, only for dyad dependent models and
+   #  init.method="MPLE"
+     if(!is.dyad.independent(m) && control$MPLE.covariance.method=="Godambe" ||
+        control$MPLE.covariance.method=="bootstrap"){
+       invHess <- summary(glm.result$value)$cov.unscaled
+       mple.cov <- ergm_mplecov(pl=pl,nw=nw, s=s, init=init, theta.mple=glm.result$value$coef, invHess=invHess,
+                                verbose=verbose, control=control, constraints=constraints,
+                                formula = formula)
+     }
     
     # error handling for glm results
     if (!is.null(glm.result$error)) {
@@ -129,7 +146,12 @@ ergm.mple<-function(s, s.obs, init=NULL,
    }
   }
   real.coef <- coef(mplefit)
-  real.cov <- mplefit.summary$cov.unscaled
+  if(!is.dyad.independent(m) && control$MPLE.covariance.method=="Godambe" ||
+     control$MPLE.covariance.method=="bootstrap" ){
+    real.cov <- mple.cov
+  }else{
+    real.cov <- mplefit.summary$cov.unscaled
+  }
 
   theta <- NVL(init, real.coef)
   theta[!m$etamap$offsettheta] <- real.coef

--- a/R/ergm.mple.R
+++ b/R/ergm.mple.R
@@ -46,11 +46,6 @@
 #' @template control
 #' @template verbose
 #'
-#' @param constraints {A formula specifying one or more constraints
-#' on the support of the distribution of the networks being modeled,
-#' using syntax similar to the \code{formula} argument, on the
-#' right-hand side.
-#'
 #' @param \dots additional parameters passed from within; all will be
 #'   ignored
 #' @return \code{ergm.mple} returns an ergm object as a list
@@ -60,12 +55,10 @@
 #' @seealso \code{\link{ergmMPLE}},
 #' \code{\link{ergm}},\code{\link{control.ergm}}
 #' @references \insertAllCited{}
-ergm.mple<-function(s, s.obs, nw, init=NULL,
+ergm.mple<-function(s, s.obs, init=NULL,
                     family="binomial",
                     control=NULL,
-                    constraints=NULL,
                     verbose=FALSE,
-                    formula = formula,
                     ...) {
   m <- s$model
   message("Starting maximum pseudolikelihood estimation (MPLE):")
@@ -110,12 +103,11 @@ ergm.mple<-function(s, s.obs, nw, init=NULL,
 
    # estimate variability matrix V for Godambe covariance matrix or via bootstrapping, only for dyad dependent models and
    #  init.method="MPLE"
-     if(!is.dyad.independent(m) && control$MPLE.covariance.method=="Godambe" ||
+     if(!is.dyad.independent(s$model) && control$MPLE.covariance.method=="Godambe" ||
         control$MPLE.covariance.method=="bootstrap"){
        invHess <- summary(glm.result$value)$cov.unscaled
-       mple.cov <- ergm_mplecov(pl=pl,nw=nw, s=s, init=init, theta.mple=glm.result$value$coef, invHess=invHess,
-                                verbose=verbose, control=control, constraints=constraints,
-                                formula = formula)
+       mple.cov <- ergm_mplecov(pl=pl, s=s, init=init, theta.mple=glm.result$value$coef, invHess=invHess,
+                                verbose=verbose, control=control)
      }
     
     # error handling for glm results
@@ -146,7 +138,7 @@ ergm.mple<-function(s, s.obs, nw, init=NULL,
    }
   }
   real.coef <- coef(mplefit)
-  if(!is.dyad.independent(m) && control$MPLE.covariance.method=="Godambe" ||
+  if(!is.dyad.independent(s$model) && control$MPLE.covariance.method=="Godambe" ||
      control$MPLE.covariance.method=="bootstrap" ){
     real.cov <- mple.cov
   }else{

--- a/R/ergm.pl.R
+++ b/R/ergm.pl.R
@@ -11,7 +11,7 @@
 #' @rdname ergm.mple
 #' @description \code{ergm.pl} is an even more internal workhorse
 #'   function that prepares many of the components needed by
-#'   \code{ergm.mple} for the regression rountines that are used to
+#'   \code{ergm.mple} for the regression routines that are used to
 #'   find the MPLE estimated ergm. It should not be called directly by
 #'   the user.
 #'

--- a/R/ergm_mplecov.R
+++ b/R/ergm_mplecov.R
@@ -1,0 +1,146 @@
+#' Approximate MPLE standard errors in dyad-dependent models
+#'
+#' Function to approximate the MPLE covariance matrix in a dyad dependence model
+#' using the Godambe matrix as described in Schmid and Hunter (2020) or by parametric bootstrap
+#' as described by Schmid and Desmarais (2017).
+#'
+#' @param pl An \code{\link{ergm.pl}} object.
+#' @param nw response network.
+#' @param m the model, as returned by \code{\link{ergm_model}}
+#' @param init a vector a vector of initial theta coefficients
+#' @param theta.mple the MPLE of a given model
+#' @param invHess the inverse Hessian matrix obtained from glm()
+#' @param control a list of MCMC related parameters; recognized
+#'   components include: samplesize : the number of networks to sample
+#'   Clist.miss : see 'Clist.miss' above; some of the code uses this
+#'   Clist.miss,
+#' @param verbose whether this and the C routines should be verbose (T
+#'   or F); default=FALSE
+#'
+#' @param constraints {A formula specifying one or more constraints
+#' on the support of the distribution of the networks being modeled,
+#' using syntax similar to the \code{formula} argument, on the
+#' right-hand side.
+#'
+#' @param family the family to use in the R native routine
+#' default="binomial"
+#'
+#' @return \code{ergm_mplecov} returns a list either
+#'   containing a Godambe covariance matrix or a diagonal matrix with bootstrap variances.
+#'
+#' @references Schmid CS and Desmarais BA (2017). "Exponential random graph
+#' models with big networks: Maximum pseudolikelihood estimation and the parametric bootstrap"
+#' _IEEE International Conference on Big Data (Big Data)_, pp. 116-121.
+#'
+#' Schmid CS and Hunter DR (2023).  "Computing Pseudolikelihood Estimators for Exponential-Family Random Graph Models" _Journal of Data Science_.
+#' @noRd
+#'
+#' @examples
+#' \donttest{
+#' # create initial network with x=50 nodes
+#' init.net <- network(x=50, directed = FALSE, density = 0.1)
+#'
+#' # true parameters for edges, kstar(2), ad triangles
+#' truth <- c(-0.25, -0.2, 0.5)
+#'
+#' # simulate a network from the ERGM defined by the true parameter values
+#' sim.net <- simulate(init.net~ edges+kstar(2)+ triangles, nsim=1, coef=truth)
+#'
+#' # get MPLE with inverse Hessian matrix
+#' fisher <- ergm(sim.net ~ edges+kstar(2)+ triangles, estimate = "MPLE",
+#' control = control.ergm(MPLE.covariance.method = "invHess"))
+#'
+#' # get MPLE with Godambe matrix
+#' godambe <- ergm(sim.net ~ edges+kstar(2)+ triangles, estimate = "MPLE",
+#' control = control.ergm(MPLE.covariance.method = "Godambe"))
+#'
+#' # get MPLE with bootstrap standard errors
+#' bootstrap <- ergm(sim.net ~ edges+kstar(2)+ triangles, estimate="MPLE",
+#' control = control.ergm(MPLE.covariance.method="bootstrap"))
+#' }
+ergm_mplecov <- function(pl,
+                         nw,
+                         s,
+                         init=init,
+                         theta.mple,
+                         invHess,
+                         control=NULL,
+                         verbose=FALSE,
+                         constraints=NULL,
+                         family="binomial",
+                         formula = formula){
+
+  m <- s$model
+  # get sample size from control.ergm
+  R <- control$MPLE.covariance.samplesize
+  mple.burnin <- control$MPLE.covariance.sim.burnin
+  mple.interval <- control$MPLE.covariance.sim.interval
+
+  # Simulate R networks
+  sim.mple <- simulate(m, basis=nw, coef=theta.mple, nsim=R,
+                       control=control.simulate.formula(MCMC.burnin=mple.burnin, MCMC.interval=mple.interval))
+
+  num.variables <- ncol(pl$xmat)
+
+  terms.form <- terms(formula)
+
+  new.formula <- reformulate(attr(terms.form, "term.labels"), "sim.mple[[i]]")
+
+  if(control$MPLE.covariance.method == "Godambe"){
+    message("Estimating Godambe Matrix using ", R, " simulated networks.")
+
+    # calculation of V(theta) = Var(u(theta,y)) using the sim.num networks
+    net.stat <- matrix(0, nrow=length(sim.mple), ncol=num.variables)
+    colnames(net.stat) <- colnames(pl$xmat)
+    u.data <- matrix(0,nrow=length(sim.mple), ncol=num.variables)
+
+    for(i in 1:length(sim.mple)){
+
+      dat <- ergmMPLE(new.formula)
+      net.stat[i,] <- summary(new.formula)
+
+      # write the response, weight and designmatrix into one matrix
+      X.dat <- cbind(dat$response, dat$weights, dat$predictor)
+
+      # calculate s(theta)
+      u.data[i,] <- sapply(1:num.variables, function(k){
+        sum(apply(X.dat, 1, function(x){
+          x[2]*(x[k+2]*(x[1] - exp(sum(theta.mple*x[(3:(num.variables+2))]))/(1+exp(sum(theta.mple*x[(3:(num.variables+2))]))) )) } ) ) } )
+
+    } # end for i
+    # calculate V.hat by estimating sd
+    u.mean <- colMeans(u.data)
+    u.sum <- matrix(0,num.variables,num.variables)
+    for(i in 1: nrow(u.data)){
+      u.diff <- u.data[i,]- u.mean
+      u.sum <- u.sum + u.diff%*%t(u.diff)
+    }
+    u.sum.n <- u.sum/(nrow(u.data)-1)
+    G <- invHess%*%u.sum.n%*%invHess
+    return(G)
+
+  } # end if Godambe
+
+  if(control$MPLE.covariance.method == "bootstrap"){
+    message("Estimating Bootstrap Standard Errors using ", R, " simulated networks.")
+
+    # create empty matrix to store mple of bootstrap samples
+    boot.mple.mat <- matrix(0, nrow=length(sim.mple), ncol=num.variables)
+    colnames(boot.mple.mat) <- colnames(pl$xmat)
+
+    for(i in 1:length(sim.mple)){
+
+      dat <- ergmMPLE(new.formula)
+
+      # calculate MPLE of simulated network
+      glm.sim <- glm(dat$response ~ .-1 , data=data.frame(dat$predictor),
+                     weights=dat$weights, family="binomial")
+      boot.mple.mat[i,] <- coef(glm.sim)
+
+    }# end for i
+    Boot.cov <- matrix(0,num.variables, num.variables)
+    diag(Boot.cov) <- apply(boot.mple.mat, 2, var)
+    return(Boot.cov)
+
+  } # end if bootstrap
+} # end function

--- a/R/ergm_mplecov.R
+++ b/R/ergm_mplecov.R
@@ -79,7 +79,7 @@ ergm_mplecov <- function(pl,
     u.data <- matrix(0,nrow=length(sim.mple), ncol=num.variables)
 
     for(i in 1:length(sim.mple)){
-      dat <- ergm.pl(sim.mple[[i]], NULL, control=control)
+      dat <- ergm.pl(sim.mple[[i]], NULL, theta.offset = init, control=control)
 
       # write the response, weight and designmatrix into one matrix
       X.dat <- cbind(dat$zy, dat$wend, dat$xmat)
@@ -112,10 +112,10 @@ ergm_mplecov <- function(pl,
 
     for(i in 1:length(sim.mple)){
 
-      dat <- ergm.pl(sim.mple[[i]], NULL, control=control)
+      dat <- ergm.pl(sim.mple[[i]], NULL, theta.offset = init, control=control)
 
       # calculate MPLE of simulated network
-      glm.sim <- glm(dat$zy ~ .-1 , data=data.frame(dat$xmat),
+      glm.sim <- glm(dat$zy ~ .-1 + offset(dat$foffset) , data=data.frame(dat$xmat),
                      weights=dat$wend, family="binomial")
       boot.mple.mat[i,] <- coef(glm.sim)
 

--- a/R/summary.ergm.R
+++ b/R/summary.ergm.R
@@ -124,9 +124,9 @@ summary.ergm <- function (object, ...,
 
   devtext <- "Deviance:"
   if (object$estimate!="MPLE" || !independence || object$reference != as.formula(~Bernoulli)) {
-    if (pseudolikelihood) {
+    if (pseudolikelihood && control$MPLE.covariance.method=="invHess") {
       devtext <- "Pseudo-deviance:"
-      ans$message <- "\nWarning:  The standard errors are based on naive pseudolikelihood and are suspect.\n"
+      ans$message <- "\nWarning:  The standard errors are based on naive pseudolikelihood and are suspect. Set control.ergm$MPLE.covariance.method='Godambe' for a simulation-based approximation of the standard errors.\n"
     } 
     else if(object$estimate == "MLE" && any(is.na(est.se) & !ans$offset & !ans$drop==0 & !ans$estimable) && 
                       (!independence || control$force.main) ) {
@@ -150,7 +150,7 @@ summary.ergm <- function (object, ...,
                              c(dyads, rdf)), 2,2, dimnames=list(c("Null","Residual"),
                                                                 c("Resid. Dev", "Resid. Df")))
     ans$devtext <- devtext
-        
+
     ans$aic <- AIC(object)
     ans$bic <- BIC(object)
     ans$mle.lik <- ERRVL(mle.lik, NA)

--- a/inst/REFERENCES.bib
+++ b/inst/REFERENCES.bib
@@ -34,4 +34,20 @@
   doi     = {10.1016/j.socnet.2008.10.003},
 }
 
+@InProceedings{ScDe17e,
+  author       = {Schmid, Christian S and Desmarais, Bruce A},
+  title        = {Exponential random graph models with big networks: Maximum pseudolikelihood estimation and the parametric bootstrap},
+  booktitle    = {2017 IEEE international conference on big data (Big Data)},
+  year         = {2017},
+  pages        = {116--121},
+  organization = {IEEE},
+}
+
+@Article{ScHu23c,
+  author  = {Schmid, Christian S. and Hunter, David. R.},
+  title   = {Computing Pseudolikelihood Estimators for Exponential-Family Random Graph Models},
+  journal = {Journal of Data Science},
+  year    = {2023},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/man/control.ergm.Rd
+++ b/man/control.ergm.Rd
@@ -276,21 +276,17 @@ all-zero columns) are dropped, with their handling controlled by
 similar diagnostic for the unconstrained MCMC sample's estimating
 functions.}
 
-\item{MPLE.covariance.samplesize}{The number of networks to simulate to approximate
-the MPLE covariance matrix using the Godambe matrix (see Schmid and Hunter (2020)) or
-parametric Bootstrapping (see Schmid and Desmarais (2017)).}
-
-\item{MPLE.covariance.method}{The method to estimate the MPLE covariance method. \code{invHess}
-returns the covariance estimate obtained from the glm()-function. \code{Godambe} estimates the
-covariance matrix using the Godambe-matrix (Schmid and Hunter (2020)). This method is recommended
-for dyad-dependent models. Alternatively, \code{bootstrap} estimates standard deviations using a parametric
-bootstrapping approach (see Schmid and Desmarais (2017)).}
-
-\item{MPLE.covariance.sim.burnin}{Number of proposals before any MCMC sampling is done to simulate
-networks for the MPLE covariance methods "Godambe" and "bootstrap".}
-
-\item{MPLE.covariance.sim.interval}{Number of proposals between simulated networks for the MPLE covariance
-methods "Godambe" and "bootstrap".}
+\item{MPLE.covariance.method, MPLE.covariance.samplesize, MPLE.covariance.sim.burnin, MPLE.covariance.sim.interval}{Controls for estimating the MPLE covariance
+matrix. \verb{MPLE.covariance method} determines the method, with
+\code{invHess} (the default) returning the covariance estimate
+obtained from the \code{\link[=glm]{glm()}}. \code{Godambe} estimates the covariance
+matrix using the Godambe-matrix \insertCite{ScHu23c}{ergm}. This
+method is recommended for dyad-dependent models. Alternatively,
+\code{bootstrap} estimates standard deviations using a parametric
+bootstrapping approach \insertCite{@see @ScDe17e}{ergm}. The
+other parameters control, respectively, the number of networks to
+simulate, the MCMC burn-in, and the MCMC interval for \code{Godambe}
+and \code{bootstrap} methods.}
 
 \item{MPLE.constraints.ignore}{If \code{TRUE}, MPLE will ignore all
 dyad-independent constraints except for those due to attributes
@@ -700,7 +696,7 @@ This function is only used within a call to the \code{\link[=ergm]{ergm()}} func
 See the \code{usage} section in \code{\link[=ergm]{ergm()}} for details.
 }
 \references{
-\itemize{
+\insertAllCited{}
 \itemize{
 \item Snijders, T.A.B. (2002), Markov Chain Monte
 Carlo Estimation of Exponential Random Graph Models.  Journal of Social
@@ -717,8 +713,6 @@ Graphical Statistics, 21: 920-939.
 \item Kristoffer Sahlin. Estimating convergence of Markov chain Monte Carlo
 simulations. Master's Thesis. Stockholm University, 2011.
 \url{https://www2.math.su.se/matstat/reports/master/2011/rep2/report.pdf}
-}
-
 }
 }
 \seealso{

--- a/man/control.ergm.Rd
+++ b/man/control.ergm.Rd
@@ -20,6 +20,10 @@ control.ergm(
   MPLE.nonvar = c("warning", "message", "error"),
   MPLE.nonident = c("warning", "message", "error"),
   MPLE.nonident.tol = 1e-10,
+  MPLE.covariance.samplesize = 500,
+  MPLE.covariance.method = "invHess",
+  MPLE.covariance.sim.burnin = 1024,
+  MPLE.covariance.sim.interval = 1024,
   MPLE.constraints.ignore = FALSE,
   MCMC.prop = trim_env(~sparse),
   MCMC.prop.weights = "default",
@@ -271,6 +275,22 @@ all-zero columns) are dropped, with their handling controlled by
 \code{MPLE.nonvar}. The corresponding \verb{MCMLE.*} arguments provide a
 similar diagnostic for the unconstrained MCMC sample's estimating
 functions.}
+
+\item{MPLE.covariance.samplesize}{The number of networks to simulate to approximate
+the MPLE covariance matrix using the Godambe matrix (see Schmid and Hunter (2020)) or
+parametric Bootstrapping (see Schmid and Desmarais (2017)).}
+
+\item{MPLE.covariance.method}{The method to estimate the MPLE covariance method. \code{invHess}
+returns the covariance estimate obtained from the glm()-function. \code{Godambe} estimates the
+covariance matrix using the Godambe-matrix (Schmid and Hunter (2020)). This method is recommended
+for dyad-dependent models. Alternatively, \code{bootstrap} estimates standard deviations using a parametric
+bootstrapping approach (see Schmid and Desmarais (2017)).}
+
+\item{MPLE.covariance.sim.burnin}{Number of proposals before any MCMC sampling is done to simulate
+networks for the MPLE covariance methods "Godambe" and "bootstrap".}
+
+\item{MPLE.covariance.sim.interval}{Number of proposals between simulated networks for the MPLE covariance
+methods "Godambe" and "bootstrap".}
 
 \item{MPLE.constraints.ignore}{If \code{TRUE}, MPLE will ignore all
 dyad-independent constraints except for those due to attributes

--- a/man/ergm.mple.Rd
+++ b/man/ergm.mple.Rd
@@ -25,7 +25,7 @@ ergm.pl(
 )
 }
 \arguments{
-\item{init}{a vector a vector of initial theta coefficients}
+\item{init}{a vector of initial theta coefficients}
 
 \item{family}{the family to use in the R native routine
 \code{\link{glm}}; only applicable if "glm" is the 'MPLEtype';
@@ -89,7 +89,7 @@ by users instead.
 
 \code{ergm.pl} is an even more internal workhorse
 function that prepares many of the components needed by
-\code{ergm.mple} for the regression rountines that are used to
+\code{ergm.mple} for the regression routines that are used to
 find the MPLE estimated ergm. It should not be called directly by
 the user.
 }

--- a/tests/testthat/test-mple-cov.R
+++ b/tests/testthat/test-mple-cov.R
@@ -21,7 +21,7 @@ test_that("Godambe covariance method for MPLE", {
   m1 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
               control=control.ergm(MPLE.covariance.method = "Godambe"))
   StdErr1 <- round(sqrt(diag(vcov(m1))), 3)
-  expect_equal(StdErr1, c(0.242, 0.056), ignore_attr = TRUE)
+  expect_equal(StdErr1, c(0.255, 0.059), ignore_attr = TRUE)
 })
 
 test_that("Inverse Hessian from logistic regression model", {
@@ -37,7 +37,7 @@ test_that("Bootstrap covariance method for MPLE", {
   m3 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
              control=control.ergm(MPLE.covariance.method = "bootstrap"))
   StdErr3 <- round(sqrt(diag(vcov(m3))), 3)
-  expect_equal(StdErr3, c(0.257, 0.059), ignore_attr = TRUE)
+  expect_equal(StdErr3, c(0.257, 0.060), ignore_attr = TRUE)
 })
 
 test_that("Bootstrap covariance method for MPLE", {

--- a/tests/testthat/test-mple-cov.R
+++ b/tests/testthat/test-mple-cov.R
@@ -1,0 +1,38 @@
+#  File tests/testthat/test-mple-cov.R in package ergm, part of the
+#  Statnet suite of packages for network analysis, https://statnet.org .
+#
+#  This software is distributed under the GPL-3 license.  It is free,
+#  open source, and has the attribution requirements (GPL Section 7) at
+#  https://statnet.org/attribution .
+#
+#  Copyright 2003-2023 Statnet Commons
+################################################################################
+
+set.seed(14392)
+N <- 50
+y <- matrix(rbinom(N^2, 1, 0.005), N, N)
+diag(y) <- 0
+y <- as.network.matrix(y, directed = FALSE)
+
+init.sim <- simulate(y ~ edges + triangles, nsim = 1, coef = c(-log(N) + 4, -0.2))
+
+test_that("Godambe covariance method for MPLE", {
+  set.seed(111)
+  m1 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
+              control=control.ergm(MPLE.covariance.method = "Godambe"))
+  expect_equal(round(coef(summary(m1))[,2], 3), c(0.242, 0.056), ignore_attr = TRUE)
+})
+
+test_that("Inverse Hessian from logistic regression model", {
+  set.seed(222) # However, this method is not stochastic
+  m2 <- ergm(init.sim ~ edges+triangles, estimate = "MPLE",
+                control=control.ergm(MPLE.covariance.method = "invHess"))
+  expect_equal(round(coef(summary(m2))[,2], 3), c(0.155, 0.034), ignore_attr = TRUE)
+})
+
+test_that("Bootstrap covariance method for MPLE", {
+  set.seed(333)
+  m3 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
+             control=control.ergm(MPLE.covariance.method = "bootstrap"))
+  expect_equal(round(coef(summary(m3))[,2], 3), c(0.257, 0.059), ignore_attr = TRUE)
+})

--- a/tests/testthat/test-mple-cov.R
+++ b/tests/testthat/test-mple-cov.R
@@ -20,31 +20,31 @@ test_that("Godambe covariance method for MPLE", {
   set.seed(111)
   m1 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
               control=control.ergm(MPLE.covariance.method = "Godambe"))
-  StdErr1 <- round(sqrt(diag(vcov(m1))), 3)
-  expect_equal(StdErr1, c(0.255, 0.059), ignore_attr = TRUE)
+  StdErr1 <- sqrt(diag(vcov(m1)))
+  expect_equal(StdErr1, c(0.255, 0.059), ignore_attr = TRUE, tolerance=.01)
 })
 
 test_that("Inverse Hessian from logistic regression model", {
   set.seed(222) # However, this method is not stochastic
   m2 <- ergm(init.sim ~ edges+triangles, estimate = "MPLE",
                 control=control.ergm(MPLE.covariance.method = "invHess"))
-  StdErr2 <- round(sqrt(diag(vcov(m2))), 3)
-  expect_equal(StdErr2, c(0.155, 0.034), ignore_attr = TRUE)
+  StdErr2 <- sqrt(diag(vcov(m2)))
+  expect_equal(StdErr2, c(0.155, 0.034), ignore_attr = TRUE, tolerance=.01)
 })
 
 test_that("Bootstrap covariance method for MPLE", {
   set.seed(333)
   m3 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
              control=control.ergm(MPLE.covariance.method = "bootstrap"))
-  StdErr3 <- round(sqrt(diag(vcov(m3))), 3)
-  expect_equal(StdErr3, c(0.257, 0.060), ignore_attr = TRUE)
+  StdErr3 <- sqrt(diag(vcov(m3)))
+  expect_equal(StdErr3, c(0.257, 0.060), ignore_attr = TRUE, tolerance=.01)
 })
 
-test_that("Bootstrap covariance method for MPLE", {
+test_that("Bootstrap covariance method for MPLE with offsets", {
   set.seed(445)
   m4 <- ergm(init.sim ~ edges + triangles + offset(triangles), offset.coef=1,
              estimate = "MPLE",
              control=control.ergm(MPLE.covariance.method = "InvHess"))
-  StdErr4 <- round(sqrt(diag(vcov(m4))), 3)
-  expect_equal(round(coef(summary(m4))[,2], 3), c(0.155, 0.034, 0), ignore_attr = TRUE)
+  StdErr4 <- sqrt(diag(vcov(m4)))
+  expect_equal(StdErr4, c(0.155, 0.034, 0), ignore_attr = TRUE, tolerance=.01)
 })

--- a/tests/testthat/test-mple-cov.R
+++ b/tests/testthat/test-mple-cov.R
@@ -20,19 +20,23 @@ test_that("Godambe covariance method for MPLE", {
   set.seed(111)
   m1 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
               control=control.ergm(MPLE.covariance.method = "Godambe"))
-  expect_equal(round(coef(summary(m1))[,2], 3), c(0.242, 0.056), ignore_attr = TRUE)
+  StdErr1 <- round(sqrt(diag(vcov(m1))), 3)
+  expect_equal(StdErr1, c(0.242, 0.056), ignore_attr = TRUE)
 })
 
 test_that("Inverse Hessian from logistic regression model", {
   set.seed(222) # However, this method is not stochastic
   m2 <- ergm(init.sim ~ edges+triangles, estimate = "MPLE",
                 control=control.ergm(MPLE.covariance.method = "invHess"))
-  expect_equal(round(coef(summary(m2))[,2], 3), c(0.155, 0.034), ignore_attr = TRUE)
+  StdErr2 <- round(sqrt(diag(vcov(m2))), 3)
+  expect_equal(StdErr2, c(0.155, 0.034), ignore_attr = TRUE)
 })
 
 test_that("Bootstrap covariance method for MPLE", {
   set.seed(333)
   m3 <- ergm(init.sim ~ edges + triangles, estimate = "MPLE",
              control=control.ergm(MPLE.covariance.method = "bootstrap"))
-  expect_equal(round(coef(summary(m3))[,2], 3), c(0.257, 0.059), ignore_attr = TRUE)
+  StdErr3 <- round(sqrt(diag(vcov(m3))), 3)
+  expect_equal(StdErr3, c(0.257, 0.059), ignore_attr = TRUE)
 })
+

--- a/tests/testthat/test-mple-cov.R
+++ b/tests/testthat/test-mple-cov.R
@@ -40,3 +40,11 @@ test_that("Bootstrap covariance method for MPLE", {
   expect_equal(StdErr3, c(0.257, 0.059), ignore_attr = TRUE)
 })
 
+test_that("Bootstrap covariance method for MPLE", {
+  set.seed(445)
+  m4 <- ergm(init.sim ~ edges + triangles + offset(triangles), offset.coef=1,
+             estimate = "MPLE",
+             control=control.ergm(MPLE.covariance.method = "InvHess"))
+  StdErr4 <- round(sqrt(diag(vcov(m4))), 3)
+  expect_equal(round(coef(summary(m4))[,2], 3), c(0.155, 0.034, 0), ignore_attr = TRUE)
+})


### PR DESCRIPTION
I added code to estimate MPLE covariance matrices. If a user requests the MPLE of a dyad-dependent model, standard errors are obtained from the glm()-function, which uses the inverse Hessian matrix to calculate the covariance matrix.
However, MPLE standard errors obtained from the logistic regression output lead to MPLE-based confidence intervals with coverage rates far below the nominal confidence level (see for example van Duijn, Gile and Handcock (2009)) and are therefore suspect.

I added two new methods in the code that are simulation based approximation of standard errors. One uses the Godambe matrix (sometimes also referred to as the Sandwich estimator), the other one approximates standard errors using parametric bootstrapping. Simulation studies have shown that these standard errors are more reliable than MPLE s.e from the logistic regression output. See Schmid and Desmarais (2017) and Schmid and Hunter (2023).
The file ergm_mplecov.R contains the code for these two methods.

Sample code:
data(florentine)
m1 <- ergm(flomarriage~ edges+triangles, estimate="MPLE", control=control.ergm(MPLE.covariance.method="Godambe")

m2 <- ergm(flomarriage~ edges+triangles, estimate="MPLE", control=control.ergm(MPLE.covariance.method="Bootstrap")

References:
Schmid, C. S. and Desmarais B. A., Exponential Random Graph Models with Big Networks: Maximum
pseudolikelihood estimation and the parametric bootstrap, IEEE International Conference on Big Data, 2017.

Schmid, C. S. and Hunter D. R., Computing Pseudolikelihood Estimators for Exponential-Family
Random Graph Models, Journal of Data Science, 2023