### PR TITLE
correct dyad indexing in ergm_block

### DIFF
--- a/inst/include/ergm_block.h
+++ b/inst/include/ergm_block.h
@@ -49,7 +49,7 @@ static inline void BlockPut2Dyad(Vertex *tail, Vertex *head, Dyad dyadindex, Blo
     if(block->directed) {
       dyadindex /= 2;
     }
-    tailindex = dyadindex / block->tails->length;
+    tailindex = dyadindex / (block->heads->length - 1);
     headindex = dyadindex % (block->heads->length - 1);
     if(tailindex == headindex) {
       headindex = block->heads->length - 1;

--- a/tests/testthat/test-proposal-bdstrattnt.R
+++ b/tests/testthat/test-proposal-bdstrattnt.R
@@ -1265,7 +1265,7 @@ test_that("BDStratTNT handles undirected heterogeneous degree bound saturation c
                   constraints = ~bd(attr = bd_attr, maxout = maxout)
                                  + blocks(attr = ~blocks_attr, levels2 = levels2)
                                  + strat(attr = ~strat_attr, pmat = pmat),
-                  control = list(MCMC.burnin = 1e5))
+                  control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -1279,7 +1279,7 @@ test_that("BDStratTNT handles undirected heterogeneous degree bound saturation c
                    constraints = ~bd(attr = bd_attr, maxout = maxout)
                                   + blocks(attr = ~blocks_attr, levels2 = levels2)
                                   + strat(attr = ~strat_attr, pmat = pmat),
-                   control = list(MCMC.burnin = 1e5))
+                   control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -1310,7 +1310,7 @@ test_that("BDStratTNT handles directed heterogeneous degree bound saturation cor
                   constraints = ~bd(attr = bd_attr, maxout = maxout, maxin = maxin)
                                  + blocks(attr = ~blocks_attr, levels2 = levels2)
                                  + strat(attr = ~strat_attr, pmat = pmat),
-                  control = list(MCMC.burnin = 1e5))
+                  control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -1327,7 +1327,7 @@ test_that("BDStratTNT handles directed heterogeneous degree bound saturation cor
                    constraints = ~bd(attr = bd_attr, maxout = maxout, maxin = maxin)
                                   + blocks(attr = ~blocks_attr, levels2 = levels2)
                                   + strat(attr = ~strat_attr, pmat = pmat),
-                   control = list(MCMC.burnin = 1e5))
+                   control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -1361,7 +1361,7 @@ test_that("BDStratTNT handles bipartite heterogeneous degree bound saturation co
                   constraints = ~bd(attr = bd_attr, maxout = maxout)
                                  + blocks(attr = ~blocks_attr, levels2 = levels2)
                                  + strat(attr = ~strat_attr, pmat = pmat),
-                  control = list(MCMC.burnin = 1e5))
+                  control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -1375,7 +1375,7 @@ test_that("BDStratTNT handles bipartite heterogeneous degree bound saturation co
                    constraints = ~bd(attr = bd_attr, maxout = maxout)
                                   + blocks(attr = ~blocks_attr, levels2 = levels2)
                                   + strat(attr = ~strat_attr, pmat = pmat),
-                   control = list(MCMC.burnin = 1e5))
+                   control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -1403,7 +1403,7 @@ test_that("BDStratTNT handles undirected homogeneous degree bound saturation cor
                   constraints = ~bd(maxout = maxout)
                                  + blocks(attr = ~blocks_attr, levels2 = levels2)
                                  + strat(attr = ~strat_attr, pmat = pmat),
-                  control = list(MCMC.burnin = 1e5))
+                  control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -1416,7 +1416,7 @@ test_that("BDStratTNT handles undirected homogeneous degree bound saturation cor
                    constraints = ~bd(maxout = maxout)
                                   + blocks(attr = ~blocks_attr, levels2 = levels2)
                                   + strat(attr = ~strat_attr, pmat = pmat),
-                   control = list(MCMC.burnin = 1e5))
+                   control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -1443,7 +1443,7 @@ test_that("BDStratTNT handles directed homogeneous degree bound saturation corre
                   constraints = ~bd(maxout = maxout, maxin = maxin)
                                  + blocks(attr = ~blocks_attr, levels2 = levels2)
                                  + strat(attr = ~strat_attr, pmat = pmat),
-                  control = list(MCMC.burnin = 1e5))
+                  control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -1458,7 +1458,7 @@ test_that("BDStratTNT handles directed homogeneous degree bound saturation corre
                    constraints = ~bd(maxout = maxout, maxin = maxin)
                                   + blocks(attr = ~blocks_attr, levels2 = levels2)
                                   + strat(attr = ~strat_attr, pmat = pmat),
-                   control = list(MCMC.burnin = 1e5))
+                   control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -1487,7 +1487,7 @@ test_that("BDStratTNT handles bipartite homogeneous degree bound saturation corr
                   constraints = ~bd(maxout = maxout)
                                  + blocks(attr = ~blocks_attr, levels2 = levels2)
                                  + strat(attr = ~strat_attr, pmat = pmat),
-                  control = list(MCMC.burnin = 1e5))
+                  control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -1500,7 +1500,7 @@ test_that("BDStratTNT handles bipartite homogeneous degree bound saturation corr
                    constraints = ~bd(maxout = maxout)
                                   + blocks(attr = ~blocks_attr, levels2 = levels2)
                                   + strat(attr = ~strat_attr, pmat = pmat),
-                   control = list(MCMC.burnin = 1e5))
+                   control = list(MCMC.burnin = 1e4))
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)

--- a/tests/testthat/test-proposal-bdstrattnt.R
+++ b/tests/testthat/test-proposal-bdstrattnt.R
@@ -1511,7 +1511,7 @@ test_that("BDStratTNT handles bipartite homogeneous degree bound saturation corr
 test_that("all free dyads vary with a blocks constraint", {
   net_size <- 17
   bip_size <- 9
-  nsim <- 100
+  nsim <- 200
 
   blocks_levels_2 <- matrix(FALSE, nrow = 3, ncol = 3)
   blocks_levels_2[1,1] <- TRUE


### PR DESCRIPTION
This PR corrects a dyad indexing error in ergm_block that affected dyad sampling in directed diagonal blocks, adds a related test to confirm that all free dyads vary with a blocks constraint, and reduces the run length of some other tests to keep total test time from increasing.