### PR TITLE
Remove unecesary lines from ergm_mplecov()

### DIFF
--- a/R/ergm_mplecov.R
+++ b/R/ergm_mplecov.R
@@ -83,8 +83,6 @@ ergm_mplecov <- function(pl,
     message("Estimating Godambe Matrix using ", R, " simulated networks.")
 
     # calculation of V(theta) = Var(u(theta,y)) using the sim.num networks
-    # net.stat <- attr(sim.mple, "stats")
-    # colnames(net.stat) <- colnames(pl$xmat)
     u.data <- matrix(0,nrow=length(sim.mple), ncol=num.variables)
 
     for(i in 1:length(sim.mple)){

--- a/R/ergm_mplecov.R
+++ b/R/ergm_mplecov.R
@@ -83,8 +83,8 @@ ergm_mplecov <- function(pl,
     message("Estimating Godambe Matrix using ", R, " simulated networks.")
 
     # calculation of V(theta) = Var(u(theta,y)) using the sim.num networks
-    net.stat <- attr(sim.mple, "stats")
-    colnames(net.stat) <- colnames(pl$xmat)
+    # net.stat <- attr(sim.mple, "stats")
+    # colnames(net.stat) <- colnames(pl$xmat)
     u.data <- matrix(0,nrow=length(sim.mple), ncol=num.variables)
 
     for(i in 1:length(sim.mple)){

--- a/tests/testthat/test-mple-cov.R
+++ b/tests/testthat/test-mple-cov.R
@@ -26,6 +26,18 @@ test_that("Godambe covariance method for MPLE", {
   expect_equal(StdErr1, c(0.255, 0.059), ignore_attr = TRUE, tolerance=.05)
 })
 
+test_that("Godambe covariance method for MPLE with offset", {
+  set.seed(111)
+  fit <- ergm(
+    init.sim ~ edges + triangles + offset(edges), 
+    offset.coef = 0,
+    estimate = "MPLE",
+    control=control.ergm(MPLE.covariance.method = "Godambe")
+  )
+  StdErr <- sqrt(diag(vcov(fit)))
+  expect_equal(StdErr, c(0.255, 0.059, 0), ignore_attr = TRUE, tolerance=.05)
+})
+
 test_that("Inverse Hessian from logistic regression model", {
   set.seed(222) # However, this method is not stochastic
   m2 <- ergm(init.sim ~ edges+triangles, estimate = "MPLE",
@@ -50,3 +62,5 @@ test_that("Bootstrap covariance method for MPLE with offsets", {
   StdErr4 <- sqrt(diag(vcov(m4)))
   expect_equal(StdErr4, c(0.155, 0.034, 0), ignore_attr = TRUE, tolerance=.05)
 })
+
+


### PR DESCRIPTION
Removing the left-overs from the initial implementation of Godambe method, which started to kick (#561).