### PR TITLE
fix small but significant typo in new spcache auxiliary documentation

### DIFF
--- a/R/InitErgmTerm.spcache.R
+++ b/R/InitErgmTerm.spcache.R
@@ -30,7 +30,7 @@
 #'
 #' To make use of it in your change statistic:
 #'
-#' 1. Add `auxiliaries = ~spcache.net(type)` to the `InitErgmTerm`
+#' 1. Add `auxiliaries = ~.spcache.net(type)` to the `InitErgmTerm`
 #'    output list. You may request it multiple times and/or alongside
 #'    other auxiliaries.
 #'

--- a/man/spcachenet-ergmAuxiliary-f1950bb3.Rd
+++ b/man/spcachenet-ergmAuxiliary-f1950bb3.Rd
@@ -22,7 +22,7 @@ defined in \file{"ergm_dyad_hashmap.h"}. It is, internally, a
 
 To make use of it in your change statistic:
 \enumerate{
-\item Add \code{auxiliaries = ~spcache.net(type)} to the \code{InitErgmTerm}
+\item Add \code{auxiliaries = ~.spcache.net(type)} to the \code{InitErgmTerm}
 output list. You may request it multiple times and/or alongside
 other auxiliaries.
 \item Add \verb{#include "ergm_dyad_hashmap.h"} to the top of your change


### PR DESCRIPTION
 should be  auxiliaries = ~.spcache.net(type)
 not auxiliaries = ~spcache.net(type) as in help page (. prefix)
  