### PR TITLE
Option for 'loopswarning'

### DIFF
--- a/R/ergm.getnetwork.R
+++ b/R/ergm.getnetwork.R
@@ -30,9 +30,12 @@
 #' is valid; if so, the network is returned; if not, execution is
 #' halted with warnings.
 #'
-#' @param formula a two-sided formula whose LHS is a [`network`], an object that can be coerced to a [`network`], or an expression that evaluates to one.
+#' @param formula a two-sided formula whose LHS is a [`network`], an object
+#'   that can be coerced to a [`network`], or an expression that evaluates
+#'   to one.
 #' @param loopswarning whether warnings about loops should be printed
-#'   (`TRUE` or `FALSE`); defaults to `TRUE`.
+#'   (`TRUE` or `FALSE`); defaults to value of option `ergm.loopswarning`
+#'   or `TRUE`.
 #' 
 #' @return A [`network`] object constructed by evaluating the LHS of
 #'   the model formula in the formula's environment.

--- a/R/ergm.getnetwork.R
+++ b/R/ergm.getnetwork.R
@@ -37,7 +37,7 @@
 #' @return A [`network`] object constructed by evaluating the LHS of
 #'   the model formula in the formula's environment.
 #' @export ergm.getnetwork
-ergm.getnetwork <- function (formula, loopswarning=TRUE){
+ergm.getnetwork <- function (formula, loopswarning=getOption("ergm.loopswarning")){
   nw <- eval_lhs.formula(formula)
   nw <- ensure_network(nw)
 

--- a/R/ergm.getnetwork.R
+++ b/R/ergm.getnetwork.R
@@ -34,13 +34,13 @@
 #'   that can be coerced to a [`network`], or an expression that evaluates
 #'   to one.
 #' @param loopswarning whether warnings about loops should be printed
-#'   (`TRUE` or `FALSE`); defaults to value of option `ergm.loopswarning`
+#'   (`TRUE` or `FALSE`); defaults to value of option `ergm.warn_loops`
 #'   or `TRUE`.
 #' 
 #' @return A [`network`] object constructed by evaluating the LHS of
 #'   the model formula in the formula's environment.
 #' @export ergm.getnetwork
-ergm.getnetwork <- function (formula, loopswarning=getOption("ergm.loopswarning")){
+ergm.getnetwork <- function (formula, loopswarning=getOption("ergm.warn_loops")){
   nw <- eval_lhs.formula(formula)
   nw <- ensure_network(nw)
 

--- a/R/ergm.getnetwork.R
+++ b/R/ergm.getnetwork.R
@@ -44,9 +44,9 @@ ergm.getnetwork <- function (formula, loopswarning=getOption("ergm.loopswarning"
   if (loopswarning) {
     e <- as.edgelist(nw)
     if(any(e[,1]==e[,2])) {
-      print("Warning:  This network contains loops")
+      warning("This network contains loops")
     } else if (has.loops(as.network(nw,populate=FALSE))) {
-      print("Warning:  This network is allowed to contain loops")
+      warning("This network is allowed to contain loops")
     }
   }
   nw

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,9 +21,12 @@
   # . is used as a placeholder by stantet.common::NVL3().
   utils::globalVariables(".")
 
-  default_options(ergm.eval.loglik=TRUE,
-                  ergm.loglik.warn_dyads=TRUE,
-                  ergm.cluster.retries=5)
+  default_options(
+    ergm.eval.loglik=TRUE,
+    ergm.loglik.warn_dyads=TRUE,
+    ergm.loopswarning = TRUE,
+    ergm.cluster.retries=5
+  )
 
   eval(COLLATE_ALL_MY_CONTROLS_EXPR)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,7 +24,7 @@
   default_options(
     ergm.eval.loglik=TRUE,
     ergm.loglik.warn_dyads=TRUE,
-    ergm.loopswarning = TRUE,
+    ergm.warn_loops = TRUE,
     ergm.cluster.retries=5
   )
 

--- a/man/ergm.getnetwork.Rd
+++ b/man/ergm.getnetwork.Rd
@@ -5,13 +5,16 @@
 \title{Acquire and verify the network from the LHS of an \code{ergm} formula
 and verify that it is a valid network.}
 \usage{
-ergm.getnetwork(formula, loopswarning = TRUE)
+ergm.getnetwork(formula, loopswarning = getOption("ergm.warn_loops"))
 }
 \arguments{
-\item{formula}{a two-sided formula whose LHS is a \code{\link[network:network]{network}}, an object that can be coerced to a \code{\link[network:network]{network}}, or an expression that evaluates to one.}
+\item{formula}{a two-sided formula whose LHS is a \code{\link[network:network]{network}}, an object
+that can be coerced to a \code{\link[network:network]{network}}, or an expression that evaluates
+to one.}
 
 \item{loopswarning}{whether warnings about loops should be printed
-(\code{TRUE} or \code{FALSE}); defaults to \code{TRUE}.}
+(\code{TRUE} or \code{FALSE}); defaults to value of option \code{ergm.warn_loops}
+or \code{TRUE}.}
 }
 \value{
 A \code{\link[network:network]{network}} object constructed by evaluating the LHS of


### PR DESCRIPTION
Adds an option `ergm.loopswarning` to mute warnings about the network having loops. Default behavior unchanged. Still needs roxygenization (see below).

@krivit Roxygen screams that the package was documented with version 7.3.2.9000 rather than latest CRAN release. However, when I installed **roxygen2** from it's repo it gives all sorts of warnings, even though the version numbers match. Did you use an own custom-patched version?