### PR TITLE
Fix for upcoming testthat 3.3.0

### DIFF
--- a/tests/testthat/test-term-Offset.R
+++ b/tests/testthat/test-term-Offset.R
@@ -16,13 +16,15 @@ test_that("Estimation with Offset() operator works", {
     ergm_model(nw ~ edges + offset(Offset(~triangle, which = 1, coef = 0.1))),
     offset_RE)
 
-  expect_failure(expect_message(
+  expect_no_message(
     off <- ergm(nw ~ edges + offset(triangle), offset.coef = 0.1),
-    offset_RE), ".* did not throw the expected message.*")
+    offset_RE
+  )
 
-  expect_failure(expect_message(
+  expect_no_message(
     Off <- ergm(nw ~ edges + Offset(~triangle, which = 1, coef = 0.1)),
-    offset_RE), ".* did not throw the expected message.*")
+    message = offset_RE
+  )
 
   expect_within_mc_err2(off, Off, 1L, TRUE)
 })

--- a/tests/testthat/test-term-Offset.R
+++ b/tests/testthat/test-term-Offset.R
@@ -18,7 +18,7 @@ test_that("Estimation with Offset() operator works", {
 
   expect_no_message(
     off <- ergm(nw ~ edges + offset(triangle), offset.coef = 0.1),
-    offset_RE
+    message = offset_RE
   )
 
   expect_no_message(


### PR DESCRIPTION
`expect_failure()` is now designed for testing custom expectations, so I just switched your tests to be more direct.